### PR TITLE
Fork log/syslog in order to support custom tags.

### DIFF
--- a/logspout.go
+++ b/logspout.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/robxu9/logspout/pkg/syslog"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/robxu9/logspout/pkg/syslog"
 
 	"code.google.com/p/go.net/websocket"
 	"github.com/fsouza/go-dockerclient"

--- a/pkg/syslog/syslog.go
+++ b/pkg/syslog/syslog.go
@@ -248,16 +248,8 @@ func (w *Writer) Debug(m string) (err error) {
 	return err
 }
 
-// WriteWithTag sends a log message to the syslog daemon with a custom
-// tag.
-func (w *Writer) WriteWithTag(m, tag string) (err error) {
-	_, err = w.writeAndRetry(w.priority, tag, m)
-	return err
-}
-
-// WriteWithTagPriority sends a log message to the syslog daemon with a
-// custom tag and priority.
-func (w *Writer) WriteWithTagPriority(m, tag string, p Priority) (err error) {
+// Send logs a message to the syslog daemon with a custom tag and priority.
+func (w *Writer) Send(m, tag string, p Priority) (err error) {
 	_, err = w.writeAndRetry(p, tag, m)
 	return err
 }

--- a/pkg/syslog/syslog.go
+++ b/pkg/syslog/syslog.go
@@ -81,8 +81,8 @@ const (
 
 // A Writer is a connection to a syslog server.
 type Writer struct {
-	Priority Priority
-	Tag      string
+	priority Priority
+	tag      string
 	hostname string
 	network  string
 	raddr    string
@@ -130,8 +130,8 @@ func Dial(network, raddr string, priority Priority, tag string) (*Writer, error)
 	hostname, _ := os.Hostname()
 
 	w := &Writer{
-		Priority: priority,
-		Tag:      tag,
+		priority: priority,
+		tag:      tag,
 		hostname: hostname,
 		network:  network,
 		raddr:    raddr,
@@ -176,7 +176,7 @@ func (w *Writer) connect() (err error) {
 
 // Write sends a log message to the syslog daemon.
 func (w *Writer) Write(b []byte) (int, error) {
-	return w.writeAndRetry(w.Priority, w.Tag, string(b))
+	return w.writeAndRetry(w.priority, w.tag, string(b))
 }
 
 // Close closes a connection to the syslog daemon.
@@ -195,71 +195,75 @@ func (w *Writer) Close() error {
 // Emerg logs a message with severity LOG_EMERG, ignoring the severity
 // passed to New.
 func (w *Writer) Emerg(m string) (err error) {
-	_, err = w.writeAndRetry(LOG_EMERG, w.Tag, m)
+	_, err = w.writeAndRetry(LOG_EMERG, w.tag, m)
 	return err
 }
 
 // Alert logs a message with severity LOG_ALERT, ignoring the severity
 // passed to New.
 func (w *Writer) Alert(m string) (err error) {
-	_, err = w.writeAndRetry(LOG_ALERT, w.Tag, m)
+	_, err = w.writeAndRetry(LOG_ALERT, w.tag, m)
 	return err
 }
 
 // Crit logs a message with severity LOG_CRIT, ignoring the severity
 // passed to New.
 func (w *Writer) Crit(m string) (err error) {
-	_, err = w.writeAndRetry(LOG_CRIT, w.Tag, m)
+	_, err = w.writeAndRetry(LOG_CRIT, w.tag, m)
 	return err
 }
 
 // Err logs a message with severity LOG_ERR, ignoring the severity
 // passed to New.
 func (w *Writer) Err(m string) (err error) {
-	_, err = w.writeAndRetry(LOG_ERR, w.Tag, m)
+	_, err = w.writeAndRetry(LOG_ERR, w.tag, m)
 	return err
 }
 
 // Warning logs a message with severity LOG_WARNING, ignoring the
 // severity passed to New.
 func (w *Writer) Warning(m string) (err error) {
-	_, err = w.writeAndRetry(LOG_WARNING, w.Tag, m)
+	_, err = w.writeAndRetry(LOG_WARNING, w.tag, m)
 	return err
 }
 
 // Notice logs a message with severity LOG_NOTICE, ignoring the
 // severity passed to New.
 func (w *Writer) Notice(m string) (err error) {
-	_, err = w.writeAndRetry(LOG_NOTICE, w.Tag, m)
+	_, err = w.writeAndRetry(LOG_NOTICE, w.tag, m)
 	return err
 }
 
 // Info logs a message with severity LOG_INFO, ignoring the severity
 // passed to New.
 func (w *Writer) Info(m string) (err error) {
-	_, err = w.writeAndRetry(LOG_INFO, w.Tag, m)
+	_, err = w.writeAndRetry(LOG_INFO, w.tag, m)
 	return err
 }
 
 // Debug logs a message with severity LOG_DEBUG, ignoring the severity
 // passed to New.
 func (w *Writer) Debug(m string) (err error) {
-	_, err = w.writeAndRetry(LOG_DEBUG, w.Tag, m)
+	_, err = w.writeAndRetry(LOG_DEBUG, w.tag, m)
 	return err
 }
 
+// WriteWithTag sends a log message to the syslog daemon with a custom
+// tag.
 func (w *Writer) WriteWithTag(m, tag string) (err error) {
-	_, err = w.writeAndRetry(w.Priority, tag, m)
+	_, err = w.writeAndRetry(w.priority, tag, m)
 	return err
 }
 
+// WriteWithTagPriority sends a log message to the syslog daemon with a
+// custom tag and priority.
 func (w *Writer) WriteWithTagPriority(m, tag string, p Priority) (err error) {
 	_, err = w.writeAndRetry(p, tag, m)
 	return err
 }
 
 func (w *Writer) writeAndRetry(p Priority, tag, s string) (int, error) {
-	pr := (w.Priority & facilityMask) | (p & severityMask)
+	pr := (w.priority & facilityMask) | (p & severityMask)
 
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/pkg/syslog/syslog.go
+++ b/pkg/syslog/syslog.go
@@ -1,0 +1,329 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows,!nacl,!plan9
+
+// Package syslog provides a simple interface to the system log
+// service. It can send messages to the syslog daemon using UNIX
+// domain sockets, UDP or TCP.
+//
+// Only one call to Dial is necessary. On write failures,
+// the syslog client will attempt to reconnect to the server
+// and write again.
+package syslog
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// The Priority is a combination of the syslog facility and
+// severity. For example, LOG_ALERT | LOG_FTP sends an alert severity
+// message from the FTP facility. The default severity is LOG_EMERG;
+// the default facility is LOG_KERN.
+type Priority int
+
+const severityMask = 0x07
+const facilityMask = 0xf8
+
+const (
+	// Severity.
+
+	// From /usr/include/sys/syslog.h.
+	// These are the same on Linux, BSD, and OS X.
+	LOG_EMERG Priority = iota
+	LOG_ALERT
+	LOG_CRIT
+	LOG_ERR
+	LOG_WARNING
+	LOG_NOTICE
+	LOG_INFO
+	LOG_DEBUG
+)
+
+const (
+	// Facility.
+
+	// From /usr/include/sys/syslog.h.
+	// These are the same up to LOG_FTP on Linux, BSD, and OS X.
+	LOG_KERN Priority = iota << 3
+	LOG_USER
+	LOG_MAIL
+	LOG_DAEMON
+	LOG_AUTH
+	LOG_SYSLOG
+	LOG_LPR
+	LOG_NEWS
+	LOG_UUCP
+	LOG_CRON
+	LOG_AUTHPRIV
+	LOG_FTP
+	_ // unused
+	_ // unused
+	_ // unused
+	_ // unused
+	LOG_LOCAL0
+	LOG_LOCAL1
+	LOG_LOCAL2
+	LOG_LOCAL3
+	LOG_LOCAL4
+	LOG_LOCAL5
+	LOG_LOCAL6
+	LOG_LOCAL7
+)
+
+// A Writer is a connection to a syslog server.
+type Writer struct {
+	Priority Priority
+	Tag      string
+	hostname string
+	network  string
+	raddr    string
+
+	mu   sync.Mutex // guards conn
+	conn serverConn
+}
+
+// This interface and the separate syslog_unix.go file exist for
+// Solaris support as implemented by gccgo.  On Solaris you can not
+// simply open a TCP connection to the syslog daemon.  The gccgo
+// sources have a syslog_solaris.go file that implements unixSyslog to
+// return a type that satisfies this interface and simply calls the C
+// library syslog function.
+type serverConn interface {
+	writeString(p Priority, hostname, tag, s, nl string) error
+	close() error
+}
+
+type netConn struct {
+	local bool
+	conn  net.Conn
+}
+
+// New establishes a new connection to the system log daemon.  Each
+// write to the returned writer sends a log message with the given
+// priority and prefix.
+func New(priority Priority, tag string) (w *Writer, err error) {
+	return Dial("", "", priority, tag)
+}
+
+// Dial establishes a connection to a log daemon by connecting to
+// address raddr on the specified network.  Each write to the returned
+// writer sends a log message with the given facility, severity and
+// tag.
+// If network is empty, Dial will connect to the local syslog server.
+func Dial(network, raddr string, priority Priority, tag string) (*Writer, error) {
+	if priority < 0 || priority > LOG_LOCAL7|LOG_DEBUG {
+		return nil, errors.New("log/syslog: invalid priority")
+	}
+
+	if tag == "" {
+		tag = os.Args[0]
+	}
+	hostname, _ := os.Hostname()
+
+	w := &Writer{
+		Priority: priority,
+		Tag:      tag,
+		hostname: hostname,
+		network:  network,
+		raddr:    raddr,
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	err := w.connect()
+	if err != nil {
+		return nil, err
+	}
+	return w, err
+}
+
+// connect makes a connection to the syslog server.
+// It must be called with w.mu held.
+func (w *Writer) connect() (err error) {
+	if w.conn != nil {
+		// ignore err from close, it makes sense to continue anyway
+		w.conn.close()
+		w.conn = nil
+	}
+
+	if w.network == "" {
+		w.conn, err = unixSyslog()
+		if w.hostname == "" {
+			w.hostname = "localhost"
+		}
+	} else {
+		var c net.Conn
+		c, err = net.Dial(w.network, w.raddr)
+		if err == nil {
+			w.conn = &netConn{conn: c}
+			if w.hostname == "" {
+				w.hostname = c.LocalAddr().String()
+			}
+		}
+	}
+	return
+}
+
+// Write sends a log message to the syslog daemon.
+func (w *Writer) Write(b []byte) (int, error) {
+	return w.writeAndRetry(w.Priority, w.Tag, string(b))
+}
+
+// Close closes a connection to the syslog daemon.
+func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.conn != nil {
+		err := w.conn.close()
+		w.conn = nil
+		return err
+	}
+	return nil
+}
+
+// Emerg logs a message with severity LOG_EMERG, ignoring the severity
+// passed to New.
+func (w *Writer) Emerg(m string) (err error) {
+	_, err = w.writeAndRetry(LOG_EMERG, w.Tag, m)
+	return err
+}
+
+// Alert logs a message with severity LOG_ALERT, ignoring the severity
+// passed to New.
+func (w *Writer) Alert(m string) (err error) {
+	_, err = w.writeAndRetry(LOG_ALERT, w.Tag, m)
+	return err
+}
+
+// Crit logs a message with severity LOG_CRIT, ignoring the severity
+// passed to New.
+func (w *Writer) Crit(m string) (err error) {
+	_, err = w.writeAndRetry(LOG_CRIT, w.Tag, m)
+	return err
+}
+
+// Err logs a message with severity LOG_ERR, ignoring the severity
+// passed to New.
+func (w *Writer) Err(m string) (err error) {
+	_, err = w.writeAndRetry(LOG_ERR, w.Tag, m)
+	return err
+}
+
+// Warning logs a message with severity LOG_WARNING, ignoring the
+// severity passed to New.
+func (w *Writer) Warning(m string) (err error) {
+	_, err = w.writeAndRetry(LOG_WARNING, w.Tag, m)
+	return err
+}
+
+// Notice logs a message with severity LOG_NOTICE, ignoring the
+// severity passed to New.
+func (w *Writer) Notice(m string) (err error) {
+	_, err = w.writeAndRetry(LOG_NOTICE, w.Tag, m)
+	return err
+}
+
+// Info logs a message with severity LOG_INFO, ignoring the severity
+// passed to New.
+func (w *Writer) Info(m string) (err error) {
+	_, err = w.writeAndRetry(LOG_INFO, w.Tag, m)
+	return err
+}
+
+// Debug logs a message with severity LOG_DEBUG, ignoring the severity
+// passed to New.
+func (w *Writer) Debug(m string) (err error) {
+	_, err = w.writeAndRetry(LOG_DEBUG, w.Tag, m)
+	return err
+}
+
+func (w *Writer) WriteWithTag(m, tag string) (err error) {
+	_, err = w.writeAndRetry(w.Priority, tag, m)
+	return err
+}
+
+func (w *Writer) WriteWithTagPriority(m, tag string, p Priority) (err error) {
+	_, err = w.writeAndRetry(p, tag, m)
+	return err
+}
+
+func (w *Writer) writeAndRetry(p Priority, tag, s string) (int, error) {
+	pr := (w.Priority & facilityMask) | (p & severityMask)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.conn != nil {
+		if n, err := w.write(pr, tag, s); err == nil {
+			return n, err
+		}
+	}
+	if err := w.connect(); err != nil {
+		return 0, err
+	}
+	return w.write(pr, tag, s)
+}
+
+// write generates and writes a syslog formatted string. The
+// format is as follows: <PRI>TIMESTAMP HOSTNAME TAG[PID]: MSG
+func (w *Writer) write(p Priority, tag, msg string) (int, error) {
+	// ensure it ends in a \n
+	nl := ""
+	if !strings.HasSuffix(msg, "\n") {
+		nl = "\n"
+	}
+
+	err := w.conn.writeString(p, w.hostname, tag, msg, nl)
+	if err != nil {
+		return 0, err
+	}
+	// Note: return the length of the input, not the number of
+	// bytes printed by Fprintf, because this must behave like
+	// an io.Writer.
+	return len(msg), nil
+}
+
+func (n *netConn) writeString(p Priority, hostname, tag, msg, nl string) error {
+	if n.local {
+		// Compared to the network form below, the changes are:
+		//	1. Use time.Stamp instead of time.RFC3339.
+		//	2. Drop the hostname field from the Fprintf.
+		timestamp := time.Now().Format(time.Stamp)
+		_, err := fmt.Fprintf(n.conn, "<%d>%s %s[%d]: %s%s",
+			p, timestamp,
+			tag, os.Getpid(), msg, nl)
+		return err
+	}
+	timestamp := time.Now().Format(time.RFC3339)
+	_, err := fmt.Fprintf(n.conn, "<%d>%s %s %s[%d]: %s%s",
+		p, timestamp, hostname,
+		tag, os.Getpid(), msg, nl)
+	return err
+}
+
+func (n *netConn) close() error {
+	return n.conn.Close()
+}
+
+// NewLogger creates a log.Logger whose output is written to
+// the system log service with the specified priority. The logFlag
+// argument is the flag set passed through to log.New to create
+// the Logger.
+func NewLogger(p Priority, logFlag int) (*log.Logger, error) {
+	s, err := New(p, "")
+	if err != nil {
+		return nil, err
+	}
+	return log.New(s, "", logFlag), nil
+}

--- a/pkg/syslog/syslog_plan9.go
+++ b/pkg/syslog/syslog_plan9.go
@@ -1,0 +1,8 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package syslog provides a simple interface to the system log service.
+package syslog
+
+// BUG(akumar): This package is not implemented on Plan 9 yet.

--- a/pkg/syslog/syslog_test.go
+++ b/pkg/syslog/syslog_test.go
@@ -1,0 +1,358 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows,!nacl,!plan9
+
+package syslog
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func runPktSyslog(c net.PacketConn, done chan<- string) {
+	var buf [4096]byte
+	var rcvd string
+	ct := 0
+	for {
+		var n int
+		var err error
+
+		c.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		n, _, err = c.ReadFrom(buf[:])
+		rcvd += string(buf[:n])
+		if err != nil {
+			if oe, ok := err.(*net.OpError); ok {
+				if ct < 3 && oe.Temporary() {
+					ct++
+					continue
+				}
+			}
+			break
+		}
+	}
+	c.Close()
+	done <- rcvd
+}
+
+var crashy = false
+
+func runStreamSyslog(l net.Listener, done chan<- string, wg *sync.WaitGroup) {
+	for {
+		var c net.Conn
+		var err error
+		if c, err = l.Accept(); err != nil {
+			return
+		}
+		wg.Add(1)
+		go func(c net.Conn) {
+			defer wg.Done()
+			c.SetReadDeadline(time.Now().Add(5 * time.Second))
+			b := bufio.NewReader(c)
+			for ct := 1; !crashy || ct&7 != 0; ct++ {
+				s, err := b.ReadString('\n')
+				if err != nil {
+					break
+				}
+				done <- s
+			}
+			c.Close()
+		}(c)
+	}
+}
+
+func startServer(n, la string, done chan<- string) (addr string, sock io.Closer, wg *sync.WaitGroup) {
+	if n == "udp" || n == "tcp" {
+		la = "127.0.0.1:0"
+	} else {
+		// unix and unixgram: choose an address if none given
+		if la == "" {
+			// use ioutil.TempFile to get a name that is unique
+			f, err := ioutil.TempFile("", "syslogtest")
+			if err != nil {
+				log.Fatal("TempFile: ", err)
+			}
+			f.Close()
+			la = f.Name()
+		}
+		os.Remove(la)
+	}
+
+	wg = new(sync.WaitGroup)
+	if n == "udp" || n == "unixgram" {
+		l, e := net.ListenPacket(n, la)
+		if e != nil {
+			log.Fatalf("startServer failed: %v", e)
+		}
+		addr = l.LocalAddr().String()
+		sock = l
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runPktSyslog(l, done)
+		}()
+	} else {
+		l, e := net.Listen(n, la)
+		if e != nil {
+			log.Fatalf("startServer failed: %v", e)
+		}
+		addr = l.Addr().String()
+		sock = l
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runStreamSyslog(l, done, wg)
+		}()
+	}
+	return
+}
+
+func TestWithSimulated(t *testing.T) {
+	msg := "Test 123"
+	transport := []string{"unix", "unixgram", "udp", "tcp"}
+
+	for _, tr := range transport {
+		done := make(chan string)
+		addr, sock, srvWG := startServer(tr, "", done)
+		defer srvWG.Wait()
+		defer sock.Close()
+		if tr == "unix" || tr == "unixgram" {
+			defer os.Remove(addr)
+		}
+		s, err := Dial(tr, addr, LOG_INFO|LOG_USER, "syslog_test")
+		if err != nil {
+			t.Fatalf("Dial() failed: %v", err)
+		}
+		err = s.Info(msg)
+		if err != nil {
+			t.Fatalf("log failed: %v", err)
+		}
+		check(t, msg, <-done)
+		s.Close()
+	}
+}
+
+func TestFlap(t *testing.T) {
+	net := "unix"
+	done := make(chan string)
+	addr, sock, srvWG := startServer(net, "", done)
+	defer srvWG.Wait()
+	defer os.Remove(addr)
+	defer sock.Close()
+
+	s, err := Dial(net, addr, LOG_INFO|LOG_USER, "syslog_test")
+	if err != nil {
+		t.Fatalf("Dial() failed: %v", err)
+	}
+	msg := "Moo 2"
+	err = s.Info(msg)
+	if err != nil {
+		t.Fatalf("log failed: %v", err)
+	}
+	check(t, msg, <-done)
+
+	// restart the server
+	_, sock2, srvWG2 := startServer(net, addr, done)
+	defer srvWG2.Wait()
+	defer sock2.Close()
+
+	// and try retransmitting
+	msg = "Moo 3"
+	err = s.Info(msg)
+	if err != nil {
+		t.Fatalf("log failed: %v", err)
+	}
+	check(t, msg, <-done)
+
+	s.Close()
+}
+
+func TestNew(t *testing.T) {
+	if LOG_LOCAL7 != 23<<3 {
+		t.Fatalf("LOG_LOCAL7 has wrong value")
+	}
+	if testing.Short() {
+		// Depends on syslog daemon running, and sometimes it's not.
+		t.Skip("skipping syslog test during -short")
+	}
+
+	s, err := New(LOG_INFO|LOG_USER, "the_tag")
+	if err != nil {
+		t.Fatalf("New() failed: %s", err)
+	}
+	// Don't send any messages.
+	s.Close()
+}
+
+func TestNewLogger(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping syslog test during -short")
+	}
+	f, err := NewLogger(LOG_USER|LOG_INFO, 0)
+	if f == nil {
+		t.Error(err)
+	}
+}
+
+func TestDial(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping syslog test during -short")
+	}
+	f, err := Dial("", "", (LOG_LOCAL7|LOG_DEBUG)+1, "syslog_test")
+	if f != nil {
+		t.Fatalf("Should have trapped bad priority")
+	}
+	f, err = Dial("", "", -1, "syslog_test")
+	if f != nil {
+		t.Fatalf("Should have trapped bad priority")
+	}
+	l, err := Dial("", "", LOG_USER|LOG_ERR, "syslog_test")
+	if err != nil {
+		t.Fatalf("Dial() failed: %s", err)
+	}
+	l.Close()
+}
+
+func check(t *testing.T, in, out string) {
+	tmpl := fmt.Sprintf("<%d>%%s %%s syslog_test[%%d]: %s\n", LOG_USER+LOG_INFO, in)
+	if hostname, err := os.Hostname(); err != nil {
+		t.Error("Error retrieving hostname")
+	} else {
+		var parsedHostname, timestamp string
+		var pid int
+		if n, err := fmt.Sscanf(out, tmpl, &timestamp, &parsedHostname, &pid); n != 3 || err != nil || hostname != parsedHostname {
+			t.Errorf("Got %q, does not match template %q (%d %s)", out, tmpl, n, err)
+		}
+	}
+}
+
+func TestWrite(t *testing.T) {
+	tests := []struct {
+		pri Priority
+		pre string
+		msg string
+		exp string
+	}{
+		{LOG_USER | LOG_ERR, "syslog_test", "", "%s %s syslog_test[%d]: \n"},
+		{LOG_USER | LOG_ERR, "syslog_test", "write test", "%s %s syslog_test[%d]: write test\n"},
+		// Write should not add \n if there already is one
+		{LOG_USER | LOG_ERR, "syslog_test", "write test 2\n", "%s %s syslog_test[%d]: write test 2\n"},
+	}
+
+	if hostname, err := os.Hostname(); err != nil {
+		t.Fatalf("Error retrieving hostname")
+	} else {
+		for _, test := range tests {
+			done := make(chan string)
+			addr, sock, srvWG := startServer("udp", "", done)
+			defer srvWG.Wait()
+			defer sock.Close()
+			l, err := Dial("udp", addr, test.pri, test.pre)
+			if err != nil {
+				t.Fatalf("syslog.Dial() failed: %v", err)
+			}
+			defer l.Close()
+			_, err = io.WriteString(l, test.msg)
+			if err != nil {
+				t.Fatalf("WriteString() failed: %v", err)
+			}
+			rcvd := <-done
+			test.exp = fmt.Sprintf("<%d>", test.pri) + test.exp
+			var parsedHostname, timestamp string
+			var pid int
+			if n, err := fmt.Sscanf(rcvd, test.exp, &timestamp, &parsedHostname, &pid); n != 3 || err != nil || hostname != parsedHostname {
+				t.Errorf("s.Info() = '%q', didn't match '%q' (%d %s)", rcvd, test.exp, n, err)
+			}
+		}
+	}
+}
+
+func TestConcurrentWrite(t *testing.T) {
+	addr, sock, srvWG := startServer("udp", "", make(chan string, 1))
+	defer srvWG.Wait()
+	defer sock.Close()
+	w, err := Dial("udp", addr, LOG_USER|LOG_ERR, "how's it going?")
+	if err != nil {
+		t.Fatalf("syslog.Dial() failed: %v", err)
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := w.Info("test")
+			if err != nil {
+				t.Errorf("Info() failed: %v", err)
+				return
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestConcurrentReconnect(t *testing.T) {
+	crashy = true
+	defer func() { crashy = false }()
+
+	const N = 10
+	const M = 100
+	net := "unix"
+	done := make(chan string, N*M)
+	addr, sock, srvWG := startServer(net, "", done)
+	defer os.Remove(addr)
+
+	// count all the messages arriving
+	count := make(chan int)
+	go func() {
+		ct := 0
+		for _ = range done {
+			ct++
+			// we are looking for 500 out of 1000 events
+			// here because lots of log messages are lost
+			// in buffers (kernel and/or bufio)
+			if ct > N*M/2 {
+				break
+			}
+		}
+		count <- ct
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			w, err := Dial(net, addr, LOG_USER|LOG_ERR, "tag")
+			if err != nil {
+				t.Fatalf("syslog.Dial() failed: %v", err)
+			}
+			defer w.Close()
+			for i := 0; i < M; i++ {
+				err := w.Info("test")
+				if err != nil {
+					t.Errorf("Info() failed: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	sock.Close()
+	srvWG.Wait()
+	close(done)
+
+	select {
+	case <-count:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("timeout in concurrent reconnect")
+	}
+}

--- a/pkg/syslog/syslog_unix.go
+++ b/pkg/syslog/syslog_unix.go
@@ -1,0 +1,31 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows,!nacl,!plan9
+
+package syslog
+
+import (
+	"errors"
+	"net"
+)
+
+// unixSyslog opens a connection to the syslog daemon running on the
+// local machine using a Unix domain socket.
+
+func unixSyslog() (conn serverConn, err error) {
+	logTypes := []string{"unixgram", "unix"}
+	logPaths := []string{"/dev/log", "/var/run/syslog"}
+	for _, network := range logTypes {
+		for _, path := range logPaths {
+			conn, err := net.Dial(network, path)
+			if err != nil {
+				continue
+			} else {
+				return &netConn{conn: conn, local: true}, nil
+			}
+		}
+	}
+	return nil, errors.New("Unix syslog delivery error")
+}

--- a/pkg/syslog/syslog_windows.go
+++ b/pkg/syslog/syslog_windows.go
@@ -1,0 +1,8 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package syslog provides a simple interface to the system log service.
+package syslog
+
+// BUG(brainman): This package is not implemented on Windows yet.


### PR DESCRIPTION
The current log/syslog package does not allow modification of the syslog
tag after a network connection is dialed. Normally this is okay, but since
logspout monitors several different processes and forwards them, we also
need to tag each process.

Additionally, tag and priority are public fields now, so if there's a need to
change the default tag and priority, it can be done.

Also, dialing every time we need to send something to syslog sucks.

Signed-off-by: Robert Xu <robxu9@gmail.com>