### PR TITLE
Fix duplicate logging

### DIFF
--- a/attacher.go
+++ b/attacher.go
@@ -30,9 +30,6 @@ func NewAttachManager(client *docker.Client) *AttachManager {
 	}
 	go func() {
 		events := make(chan *docker.APIEvents)
-		// TODO: resolve this workaround. https://github.com/fsouza/go-dockerclient/issues/101
-		assert(client.AddEventListener(events), "attacher")
-		assert(client.RemoveEventListener(events), "attacher")
 		assert(client.AddEventListener(events), "attacher")
 		for msg := range events {
 			debug("event:", msg.ID[:12], msg.Status)


### PR DESCRIPTION
Regarding https://github.com/progrium/logspout/issues/5.

This PR removes the workaround for https://github.com/fsouza/go-dockerclient/issues/101. The issue with event listeners appears to have been fixed in docker 1.0 (?), and retaining the workaround results in logspout echoing logs twice.
