### PR TITLE
make it easier to build the docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-build
+image/logspout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
-FROM flynn/busybox
-MAINTAINER Jeff Lindsay <progrium@gmail.com>
+# This Dockerfile is used to build the logspout binary only. See
+# image/Dockerfile for building a much leaner release image.
 
-ADD ./build/logspout /bin/logspout
-
-ENV DOCKER unix:///tmp/docker.sock
-ENV ROUTESPATH /mnt/routes
-VOLUME /mnt/routes
-
-EXPOSE 8000
-
-ENTRYPOINT ["/bin/logspout"]
-CMD []
+FROM google/golang
+ADD . /gopath/src/logspout
+RUN go get -v logspout

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-build/container: build/logspout Dockerfile
-	docker build --no-cache -t logspout .
-	touch build/container
+PWD := $(shell pwd)
 
-build/logspout: *.go
-	go build -o build/logspout
+all:
+	docker build -t logspout-build .
+	docker run --rm -v ${PWD}/image:/image:rw logspout-build cp /gopath/bin/logspout /image/
+	docker build -t logspout image
 
 release:
 	docker tag logspout progrium/logspout
@@ -11,4 +11,4 @@ release:
 
 .PHONY: clean
 clean:
-	rm -rf build
+	rm -rf image/logspout

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,0 +1,13 @@
+FROM flynn/busybox
+MAINTAINER Jeff Lindsay <progrium@gmail.com>
+
+ADD logspout /bin/logspout
+
+ENV DOCKER unix:///tmp/docker.sock
+ENV ROUTESPATH /mnt/routes
+VOLUME /mnt/routes
+
+EXPOSE 8000
+
+ENTRYPOINT ["/bin/logspout"]
+CMD []


### PR DESCRIPTION
i don't want to have to install Go, setup $GOPATH, install Go deps ... all on
the host, just to produce a binary to include in the docker image. building
should happen within the docker image so that host can be left intact.

to build and produce the image, merely run:

```
make
```
