### PR TITLE
use DOCKER_HOST to connect to remote socket

### DIFF
--- a/logspout.go
+++ b/logspout.go
@@ -128,7 +128,7 @@ func httpStreamer(w http.ResponseWriter, req *http.Request, logstream chan *Log,
 func main() {
 	debugMode = getopt("DEBUG", "") != ""
 	port := getopt("PORT", "8000")
-	endpoint := getopt("DOCKER", "unix:///var/run/docker.sock")
+	endpoint := getopt("DOCKER_HOST", "unix:///var/run/docker.sock")
 	routespath := getopt("ROUTESPATH", "/var/lib/logspout")
 
 	client, err := docker.NewClient(endpoint)


### PR DESCRIPTION
The Docker client respects DOCKER_HOST to set the -H flag for the
client. Using the same envvar makes it easier for development on
platforms like OSX where DOCKER_HOST is recommended to connect to
boot2docker.

Signed-off-by: Matthew Fisher matthewf@opdemand.com
