### PR TITLE
Removed attach on restart event

### DIFF
--- a/attacher.go
+++ b/attacher.go
@@ -33,7 +33,7 @@ func NewAttachManager(client *docker.Client) *AttachManager {
 		assert(client.AddEventListener(events), "attacher")
 		for msg := range events {
 			debug("event:", msg.ID[:12], msg.Status)
-			if msg.Status == "start" || msg.Status == "restart" {
+			if msg.Status == "start" {
 				go m.attach(msg.ID[:12])
 			}
 		}


### PR DESCRIPTION
Removed attach on restart event, because when a docker container is restarted, it doubles up the log entries.