### PR TITLE
Allow env vars in stream URLs

### DIFF
--- a/router/routes.go
+++ b/router/routes.go
@@ -58,7 +58,8 @@ func (rm *RouteManager) GetAll() ([]*Route, error) {
 }
 
 func (rm *RouteManager) AddFromUri(uri string) error {
-	u, err := url.Parse(uri)
+	expandedRoute := os.ExpandEnv(uri)
+	u, err := url.Parse(expandedRoute)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
My personal use case for this is to use Kubernetes service env vars to route logs.