### PR TITLE
allow comma separated syslog targets on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Logspout is a very small Docker container (14MB virtual, based on busybox), so y
 
 #### Route all container output to remote syslog
 
-The simplest way to use logspout is to just take all logs and ship to a remote syslog. Just pass a default syslog target URI as the command. Also, we always mount the Docker Unix socket with `-v` to `/tmp/docker.sock`:
+The simplest way to use logspout is to just take all logs and ship to a remote syslog. Just pass a comma separated list of syslog target URIs as the command. Also, we always mount the Docker Unix socket with `-v` to `/tmp/docker.sock`:
 
-	$ docker run -v=/var/run/docker.sock:/tmp/docker.sock progrium/logspout syslog://logs.papertrailapp.com:55555
+	$ docker run -v=/var/run/docker.sock:/tmp/docker.sock progrium/logspout syslog://logs.papertrailapp.com:55555,syslog://mysyslogserver.com:514
 
 Logs will be tagged with the container name. The hostname will be the hostname of the logspout container, so you probably want to set the container hostname to the actual hostname by adding `-h $HOSTNAME`.
 

--- a/logspout.go
+++ b/logspout.go
@@ -185,32 +185,34 @@ func main() {
 	router := NewRouteManager(attacher)
 
 	if len(os.Args) > 1 {
-		u, err := url.Parse(os.Args[1])
-		assert(err, "url")
-		log.Println("routing all to " + os.Args[1])
+		routes := strings.Split(os.Args[1], ",")
+		for _, route := range routes {
+			u, err := url.Parse(route)
+			assert(err, "url")
+			log.Println("routing all to " + route)
 
-		r := Route{
-			Target: Target{
-				Type: u.Scheme,
-				Addr: u.Host,
-			},
-		}
-		if u.RawQuery != "" {
-			v, err := url.ParseQuery(u.RawQuery)
-			assert(err, "query")
-
-			if v.Get("filter") != "" || v.Get("types") != "" {
-				r.Source = &Source{
-					Filter: v.Get("filter"),
-					Types:  strings.Split(v.Get("types"), ","),
-				}
+			r := Route{
+				Target: Target{
+					Type: u.Scheme,
+					Addr: u.Host,
+				},
 			}
+			if u.RawQuery != "" {
+				v, err := url.ParseQuery(u.RawQuery)
+				assert(err, "query")
 
-			r.Target.StructuredData = v.Get("structuredData")
-			r.Target.AppendTag = v.Get("appendTag")
+				if v.Get("filter") != "" || v.Get("types") != "" {
+					r.Source = &Source{
+						Filter: v.Get("filter"),
+						Types:  strings.Split(v.Get("types"), ","),
+					}
+				}
+
+				r.Target.StructuredData = v.Get("structuredData")
+				r.Target.AppendTag = v.Get("appendTag")
+			}
+			router.Add(&r)
 		}
-
-		router.Add(&r)
 	}
 
 	if _, err := os.Stat(routespath); err == nil {


### PR DESCRIPTION
This PR allows a user to pass a comma separated list of default syslog targets, rather than just one.