### PR TITLE
Add redis route target

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,19 @@ Logspout is a very small Docker container (14MB virtual, based on busybox), so y
 
 ## Using logspout
 
-#### Route all container output to remote syslog
+#### Route all container output to a remote
 
 The simplest way to use logspout is to just take all logs and ship to a remote syslog. Just pass a default syslog target URI as the command. Also, we always mount the Docker Unix socket with `-v` to `/tmp/docker.sock`:
 
 	$ docker run -v=/var/run/docker.sock:/tmp/docker.sock progrium/logspout syslog://logs.papertrailapp.com:55555
 
 Logs will be tagged with the container name. The hostname will be the hostname of the logspout container, so you probably want to set the container hostname to the actual hostname by adding `-h $HOSTNAME`.
+
+Likewise, a default redis target URI may be supplied:
+
+	$ docker run -v=/var/run/docker.sock:/tmp/docker.sock progrium/logspout redis://redis.papertrailapp.com:6379
+
+Logs will be appended to list stored at a key matching the container name.
 
 #### Inspect log streams using curl
 
@@ -68,7 +74,7 @@ Since `/logs` and `/logs/filter:<string>` endpoints can return logs from multipl
 
 ### Routes Resource
 
-Routes let you configure logspout to hand-off logs to another system. Right now the only supported target type is via UDP `syslog`, but hey that's pretty much everything.
+Routes let you configure logspout to hand-off logs to another system. Right now the only supported targets are via `redis` and UDP `syslog`.
 
 #### Creating a route
 

--- a/logspout.go
+++ b/logspout.go
@@ -16,6 +16,7 @@ import (
 
 	"code.google.com/p/go.net/websocket"
 	"github.com/fsouza/go-dockerclient"
+	"github.com/garyburd/redigo/redis"
 	"github.com/go-martini/martini"
 )
 
@@ -112,6 +113,37 @@ func rfc5424Streamer(target Target, types []string, logstream chan *Log) {
 		timestamp := time.Now().Format(time.RFC3339)
 		_, err := fmt.Fprintf(c, "<%d>1 %s %s %s %d - [%s] %s%s", pri, timestamp, hostname, tag, os.Getpid(), target.StructuredData, logline.Data, nl)
 		assert(err, "rfc5424")
+	}
+}
+
+func redisStreamer(target Target, types []string, logstream chan *Log) {
+	pool := &redis.Pool{
+		MaxIdle: 10,
+		IdleTimeout: 30 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			c, err := redis.Dial("tcp", target.Addr)
+			if err != nil {
+				return nil, err
+			}
+			return c, err
+		},
+		TestOnBorrow: func(c redis.Conn, t time.Time) error {
+			_, err := c.Do("PING")
+			return err
+		},
+	}
+	typestr := "," + strings.Join(types, ",") + ","
+	conn := pool.Get()
+	defer conn.Close()
+	for logline := range logstream {
+		if typestr != ",," && !strings.Contains(typestr, logline.Type) {
+			continue
+		}
+		tag := logline.Name + target.AppendTag
+		_, err := conn.Do("RPUSH", tag, logline.Data)
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/routes.go
+++ b/routes.go
@@ -87,6 +87,8 @@ func (rm *RouteManager) Add(route *Route) error {
 			go syslogStreamer(route.Target, types, logstream)
 		case "udp+json":
 			go udpStreamer(route.Target, types, logstream)
+		case "redis":
+			go redisStreamer(route.Target, types, logstream)
 		}
 		rm.attacher.Listen(route.Source, logstream, route.closer)
 	}()


### PR DESCRIPTION
This is a rebase of https://github.com/progrium/logspout/pull/24.
Streams output to redis, appending to a list named after the container. Ideas for improvement or future features:
- option to append all logs to a specific key?
- using pub/sub instead of a list
