### PR TITLE
Send docker container hostname in log messages

### DIFF
--- a/logspout.go
+++ b/logspout.go
@@ -76,6 +76,10 @@ func main() {
 
 				r.Target.StructuredData = v.Get("structuredData")
 				r.Target.AppendTag = v.Get("appendTag")
+
+				if v.Get("useContainerHostname") == "true" {
+					r.Target.UseContainerHostname = true
+				}
 			}
 			router.Router.Add(&r)
 		}

--- a/router/streamers.go
+++ b/router/streamers.go
@@ -91,7 +91,9 @@ func rfc5424Streamer(target Target, types []string, logstream chan *Log) {
 		if !strings.HasSuffix(logline.Data, "\n") {
 			nl = "\n"
 		}
-
+		if target.UseContainerHostname {
+			hostname = logline.Hostname
+		}
 		timestamp := time.Now().Format(time.RFC3339)
 		_, err := fmt.Fprintf(c, "<%d>1 %s %s %s %d - [%s] %s%s", pri, timestamp, hostname, tag, os.Getpid(), target.StructuredData, logline.Data, nl)
 		assert(err, "rfc5424")

--- a/router/types.go
+++ b/router/types.go
@@ -14,10 +14,11 @@ type AttachEvent struct {
 }
 
 type Log struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Type string `json:"type"`
-	Data string `json:"data"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Hostname string `json:"hostname"`
+	Type     string `json:"type"`
+	Data     string `json:"data"`
 }
 
 type Route struct {
@@ -40,10 +41,11 @@ func (s *Source) All() bool {
 }
 
 type Target struct {
-	Type           string `json:"type"`
-	Addr           string `json:"addr"`
-	AppendTag      string `json:"append_tag,omitempty"`
-	StructuredData string `json:"structured_data,omitempty"`
+	Type                 string `json:"type"`
+	Addr                 string `json:"addr"`
+	AppendTag            string `json:"append_tag,omitempty"`
+	StructuredData       string `json:"structured_data,omitempty"`
+	UseContainerHostname bool `json:"send_container_hostname,omitempty"`
 }
 
 func marshal(obj interface{}) []byte {


### PR DESCRIPTION
Allow you to send the container 'hostname' rather than the hostname of the host/container in which logspout is running when using the RFC5424 streamer. 