### PR TITLE
Kafka logspout adapter

### DIFF
--- a/adapters/kafka/kafka.go
+++ b/adapters/kafka/kafka.go
@@ -35,10 +35,10 @@ func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
 	}
 
 	var tmpl *template.Template
-	if text := os.Getenv("KAFKA_FORMAT"); text != "" {
+	if text := os.Getenv("KAFKA_TEMPLATE"); text != "" {
 		tmpl, err = template.New("kafka").Parse(text)
 		if err != nil {
-			return nil, fmt.Errorf("couldn't create template from KAFKA_FORMAT: %v", err)
+			return nil, err
 		}
 	}
 

--- a/adapters/kafka/kafka.go
+++ b/adapters/kafka/kafka.go
@@ -1,0 +1,125 @@
+package kafka
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/gliderlabs/logspout/router"
+	"gopkg.in/Shopify/sarama.v1"
+)
+
+func init() {
+	router.AdapterFactories.Register(NewKafkaAdapter, "kafka")
+}
+
+type KafkaAdapter struct {
+	route    *router.Route
+	brokers  []string
+	topic    string
+	config   *sarama.Config
+	client   sarama.Client
+	producer sarama.AsyncProducer
+	tmpl     *template.Template
+}
+
+func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
+	brokers, topic, err := parseKafkaAddress(route.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := buildConfig(route.Options)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't prepare Kafka config from route options: %v", err)
+	}
+
+	var tmpl *template.Template
+	if text := os.Getenv("KAFKA_FORMAT"); text != "" {
+		tmpl, err = template.New("kafka").Parse(text)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't create template from KAFKA_FORMAT: %v", err)
+		}
+	}
+
+	client, err := sarama.NewClient(brokers, config)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create Kafka client: %v", err)
+	}
+
+	producer, err := sarama.NewAsyncProducerFromClient(client)
+	if err != nil {
+		client.Close()
+		return nil, fmt.Errorf("couldn't create Kafka producer: %v", err)
+	}
+
+	return &KafkaAdapter{
+		route:    route,
+		brokers:  brokers,
+		topic:    topic,
+		config:   config,
+		client:   client,
+		producer: producer,
+		tmpl:     tmpl,
+	}, nil
+}
+
+func (a *KafkaAdapter) Stream(logstream chan *router.Message) {
+	for rm := range logstream {
+		message, err := a.formatMessage(rm)
+		if err != nil {
+			log.Println("kafka:", err)
+			a.route.Close()
+			break
+		}
+
+		a.producer.Input() <- message
+	}
+
+	a.producer.Close()
+	a.client.Close()
+}
+
+func buildConfig(options map[string]string) (*sarama.Config, error) {
+	config := sarama.NewConfig()
+	config.ClientID = "logspout"
+	config.Producer.Flush.Frequency = 1 * time.Second
+	config.Producer.Compression = sarama.CompressionSnappy
+	config.Producer.RequiredAcks = sarama.WaitForLocal
+
+	return config, nil
+}
+
+func (a *KafkaAdapter) formatMessage(message *router.Message) (*sarama.ProducerMessage, error) {
+	var encoder sarama.Encoder
+	if a.tmpl != nil {
+		var w bytes.Buffer
+		if err := a.tmpl.Execute(&w, message); err != nil {
+			return nil, err
+		}
+		encoder = sarama.ByteEncoder(w.Bytes())
+	} else {
+		encoder = sarama.StringEncoder(message.Data)
+	}
+
+	return &sarama.ProducerMessage{
+		Topic: a.topic,
+		Value: encoder,
+	}, nil
+}
+
+func parseKafkaAddress(routeAddress string) ([]string, string, error) {
+	if !strings.Contains(routeAddress, "/") {
+		return []string{}, "", errors.New("the route address didn't specify the Kafka topic")
+	}
+
+	slash := strings.Index(routeAddress, "/")
+	topic := routeAddress[slash+1:]
+	addrs := strings.Split(routeAddress[:slash], ",")
+	return addrs, topic, nil
+}

--- a/adapters/kafka/kafka.go
+++ b/adapters/kafka/kafka.go
@@ -28,7 +28,7 @@ type KafkaAdapter struct {
 }
 
 func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
-	brokers, topic, err := parseKafkaAddress(route.Address)
+	brokers, topic, err := parseRouteAddress(route.Address)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (a *KafkaAdapter) formatMessage(message *router.Message) (*sarama.ProducerM
 	}, nil
 }
 
-func parseKafkaAddress(routeAddress string) ([]string, string, error) {
+func parseRouteAddress(routeAddress string) ([]string, string, error) {
 	if !strings.Contains(routeAddress, "/") {
 		return []string{}, "", errors.New("the route address didn't specify the Kafka topic")
 	}

--- a/adapters/kafka/kafka.go
+++ b/adapters/kafka/kafka.go
@@ -74,6 +74,8 @@ func (a *KafkaAdapter) Stream(logstream chan *router.Message) {
 func buildConfig(options map[string]string) *sarama.Config {
 	config := sarama.NewConfig()
 	config.ClientID = "logspout"
+	config.Producer.Return.Errors = false
+	config.Producer.Return.Successes = false
 	config.Producer.Flush.Frequency = 1 * time.Second
 	config.Producer.RequiredAcks = sarama.WaitForLocal
 

--- a/adapters/kafka/kafka_test.go
+++ b/adapters/kafka/kafka_test.go
@@ -1,6 +1,10 @@
 package kafka
 
-import "testing"
+import (
+	"testing"
+
+	"gopkg.in/Shopify/sarama.v1"
+)
 
 func Test_route_address(t *testing.T) {
 	brokers, topic, err := parseKafkaAddress("broker1:9020,broker2:9020/hello")
@@ -27,3 +31,27 @@ func Test_route_address_is_missing_a_topic(t *testing.T) {
 		t.Errorf("expected an error for a missing topic")
 	}
 }
+
+func Test_build_config_with_compression_codec_option(t *testing.T) {
+	config := buildConfig(map[string]string{})
+	if config.Producer.Compression != sarama.CompressionNone {
+		t.Errorf("expected no compression codec")
+	}
+
+	config = buildConfig(map[string]string{
+		"compression.codec": "snappy",
+	})
+
+	if config.Producer.Compression != sarama.CompressionSnappy {
+		t.Errorf("expected snappy compression codec")
+	}
+
+	config = buildConfig(map[string]string{
+		"compression.codec": "gzip",
+	})
+
+	if config.Producer.Compression != sarama.CompressionGZIP {
+		t.Errorf("expected gzip compression codec")
+	}
+}
+

--- a/adapters/kafka/kafka_test.go
+++ b/adapters/kafka/kafka_test.go
@@ -1,0 +1,29 @@
+package kafka
+
+import "testing"
+
+func Test_route_address(t *testing.T) {
+	brokers, topic, err := parseKafkaAddress("broker1:9020,broker2:9020/hello")
+	if err != nil {
+		t.Errorf("unexpected err: %v", err)
+	}
+	if len(brokers) != 2 {
+		t.Fatal("expected two broker addrs")
+	}
+	if brokers[0] != "broker1:9020" {
+		t.Errorf("broker1 addr should not be %s", brokers[0])
+	}
+	if brokers[1] != "broker2:9020" {
+		t.Errorf("broker2 addr should not be %s", brokers[1])
+	}
+	if topic != "hello" {
+		t.Errorf("topic should not be %s", topic)
+	}
+}
+
+func Test_route_address_is_missing_a_topic(t *testing.T) {
+	_, _, err := parseKafkaAddress("broker1:9020,broker2:9020")
+	if err == nil {
+		t.Errorf("expected an error for a missing topic")
+	}
+}

--- a/adapters/kafka/kafka_test.go
+++ b/adapters/kafka/kafka_test.go
@@ -1,10 +1,6 @@
 package kafka
 
-import (
-	"testing"
-
-	"gopkg.in/Shopify/sarama.v1"
-)
+import "testing"
 
 func Test_route_address(t *testing.T) {
 	brokers, topic, err := parseRouteAddress("broker1:9020,broker2:9020/hello")
@@ -31,27 +27,3 @@ func Test_route_address_is_missing_a_topic(t *testing.T) {
 		t.Errorf("expected an error for a missing topic")
 	}
 }
-
-func Test_build_config_with_compression_codec_option(t *testing.T) {
-	config := buildConfig(map[string]string{})
-	if config.Producer.Compression != sarama.CompressionNone {
-		t.Errorf("expected no compression codec")
-	}
-
-	config = buildConfig(map[string]string{
-		"compression.codec": "snappy",
-	})
-
-	if config.Producer.Compression != sarama.CompressionSnappy {
-		t.Errorf("expected snappy compression codec")
-	}
-
-	config = buildConfig(map[string]string{
-		"compression.codec": "gzip",
-	})
-
-	if config.Producer.Compression != sarama.CompressionGZIP {
-		t.Errorf("expected gzip compression codec")
-	}
-}
-

--- a/adapters/kafka/kafka_test.go
+++ b/adapters/kafka/kafka_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Test_route_address(t *testing.T) {
-	brokers, topic, err := parseKafkaAddress("broker1:9020,broker2:9020/hello")
+	brokers, topic, err := parseRouteAddress("broker1:9020,broker2:9020/hello")
 	if err != nil {
 		t.Errorf("unexpected err: %v", err)
 	}
@@ -26,7 +26,7 @@ func Test_route_address(t *testing.T) {
 }
 
 func Test_route_address_is_missing_a_topic(t *testing.T) {
-	_, _, err := parseKafkaAddress("broker1:9020,broker2:9020")
+	_, _, err := parseRouteAddress("broker1:9020,broker2:9020")
 	if err == nil {
 		t.Errorf("expected an error for a missing topic")
 	}

--- a/modules.go
+++ b/modules.go
@@ -3,6 +3,7 @@ package main
 import (
 	_ "github.com/gliderlabs/logspout/adapters/raw"
 	_ "github.com/gliderlabs/logspout/adapters/syslog"
+	_ "github.com/gliderlabs/logspout/adapters/kafka"
 	_ "github.com/gliderlabs/logspout/httpstream"
 	_ "github.com/gliderlabs/logspout/routesapi"
 	_ "github.com/gliderlabs/logspout/transports/tcp"


### PR DESCRIPTION
This is a cut of the Kafka adapter/module discussed in #35.

Some things to discuss:

- I've overloaded route "address" with multiple brokers separated by "," followed by a "/" and a Kafka topic. (i.e., broker1:9020,broker2:9020/topic) The topic is so important here that it doesn't seem to fit well as a route "option".
- There are tons of Kafka producer options that can be added. I've setup "compression codec" but not gone any further yet.
- `adapters/raw` has `RAW_FORMAT`, which is a go template, and `adapters/syslog` has `SYSLOG_FORMAT` which is very much not a go template. Wondering if `KAFKA_FORMAT` is actually appropriate.
- Master branch is completely unusable for me, not sure if it's just me yet. The magic of `make dev` is gone. Most of what is in this PR worked great before the 'adapters' change, but I can't expect a merge until things settle down.

Happy to make changes, move it, etc.