### PR TITLE
allowing easy custom builds of logspout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ VOLUME /mnt/routes
 EXPOSE 8000
 
 COPY . /go/src/github.com/gliderlabs/logspout
+ONBUILD COPY ./modules.go /go/src/github.com/gliderlabs/logspout/modules.go
 RUN apk-install go git mercurial \
 	&& cd /go/src/github.com/gliderlabs/logspout \
 	&& export GOPATH=/go \

--- a/custom/Dockerfile
+++ b/custom/Dockerfile
@@ -1,0 +1,2 @@
+FROM gliderlabs/logspout:master
+ENV SYSLOG_FORMAT rfc3164

--- a/custom/README.md
+++ b/custom/README.md
@@ -1,0 +1,16 @@
+# Custom Logspout Builds
+
+Forking logspout to change modules is unnecessary! Instead, you can create an
+empty Dockerfile based on logspout and include a new `modules.go` file for the
+build context that will override the standard one.
+
+This directory is an example of doing this. It pairs logspout down to just the
+syslog adapter and TCP transport. Note this means you can only create routes
+with `syslog+tcp` as the adapter.
+
+It also shows you can take this opportunity to change default configuration by
+setting environment in the Dockefile. Here we change the syslog adapter format
+from the default of `rfc5424` to old school `rfc3164`.
+
+Now you just have to `docker build` with this Dockerfile and you'll get a custom
+logspout container image. No need to install Go, no need to maintain a fork.

--- a/custom/modules.go
+++ b/custom/modules.go
@@ -1,0 +1,6 @@
+package main
+
+import (
+	_ "github.com/gliderlabs/logspout/adapters/syslog"
+	_ "github.com/gliderlabs/logspout/transports/tcp"
+)


### PR DESCRIPTION
ONBUILD hook for overriding `modules.go` and example directory