### PR TITLE
new boot output, improved architecture, little fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ dev:
 	@docker history $(NAME):dev &> /dev/null \
 		|| docker build -f Dockerfile.dev -t $(NAME):dev .
 	@docker run --rm \
-		-e DEBUG=1 \
-		-v /var/run/docker.sock:/tmp/docker.sock \
+		-e DEBUG=true \
+		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(PWD):/go/src/github.com/gliderlabs/logspout \
-		-p 8000:8000 \
+		-p 8000:80 \
 		-e ROUTE_URIS=$(ROUTE) \
 		$(NAME):dev
 

--- a/debug/Makefile
+++ b/debug/Makefile
@@ -1,0 +1,12 @@
+MODE ?= udp
+
+debug:
+	@docker history logspout-debug &> /dev/null \
+		|| docker build -f Dockerfile -t logspout-debug .
+ifeq ($(MODE), udp)
+	@echo udp mode
+	@docker run --rm -e LOGSPOUT=ignore --name logspout-debug logspout-debug nc -lvup 9000
+else
+	@echo tcp mode
+	@docker run --rm -e LOGSPOUT=ignore --name logspout-debug logspout-debug nc -lvp 9000
+endif

--- a/router/extpoints.go
+++ b/router/extpoints.go
@@ -153,6 +153,15 @@ func (ep *httpHandlerExt) All() map[string]HttpHandler {
 	return all
 }
 
+func (ep *httpHandlerExt) Names() []string {
+	var names []string
+	for k := range ep.all() {
+		names = append(names, k)
+	}
+	return names
+}
+
+
 // AdapterFactory
 
 var AdapterFactories = &adapterFactoryExt{
@@ -187,6 +196,15 @@ func (ep *adapterFactoryExt) All() map[string]AdapterFactory {
 	return all
 }
 
+func (ep *adapterFactoryExt) Names() []string {
+	var names []string
+	for k := range ep.all() {
+		names = append(names, k)
+	}
+	return names
+}
+
+
 // AdapterTransport
 
 var AdapterTransports = &adapterTransportExt{
@@ -220,4 +238,99 @@ func (ep *adapterTransportExt) All() map[string]AdapterTransport {
 	}
 	return all
 }
+
+func (ep *adapterTransportExt) Names() []string {
+	var names []string
+	for k := range ep.all() {
+		names = append(names, k)
+	}
+	return names
+}
+
+
+// Job
+
+var Jobs = &jobExt{
+	newExtensionPoint(new(Job)),
+}
+
+type jobExt struct {
+	*extensionPoint
+}
+
+func (ep *jobExt) Unregister(name string) bool {
+	return ep.unregister(name)
+}
+
+func (ep *jobExt) Register(component Job, name string) bool {
+	return ep.register(component, name)
+}
+
+func (ep *jobExt) Lookup(name string) (Job, bool) {
+	ext, ok := ep.lookup(name)
+	if !ok {
+		return nil, ok
+	}
+	return ext.(Job), ok
+}
+
+func (ep *jobExt) All() map[string]Job {
+	all := make(map[string]Job)
+	for k, v := range ep.all() {
+		all[k] = v.(Job)
+	}
+	return all
+}
+
+func (ep *jobExt) Names() []string {
+	var names []string
+	for k := range ep.all() {
+		names = append(names, k)
+	}
+	return names
+}
+
+
+// LogRouter
+
+var LogRouters = &logRouterExt{
+	newExtensionPoint(new(LogRouter)),
+}
+
+type logRouterExt struct {
+	*extensionPoint
+}
+
+func (ep *logRouterExt) Unregister(name string) bool {
+	return ep.unregister(name)
+}
+
+func (ep *logRouterExt) Register(component LogRouter, name string) bool {
+	return ep.register(component, name)
+}
+
+func (ep *logRouterExt) Lookup(name string) (LogRouter, bool) {
+	ext, ok := ep.lookup(name)
+	if !ok {
+		return nil, ok
+	}
+	return ext.(LogRouter), ok
+}
+
+func (ep *logRouterExt) All() map[string]LogRouter {
+	all := make(map[string]LogRouter)
+	for k, v := range ep.all() {
+		all[k] = v.(LogRouter)
+	}
+	return all
+}
+
+func (ep *logRouterExt) Names() []string {
+	var names []string
+	for k := range ep.all() {
+		names = append(names, k)
+	}
+	return names
+}
+
 

--- a/router/http.go
+++ b/router/http.go
@@ -1,0 +1,34 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func init() {
+	port := getopt("PORT", getopt("HTTP_PORT", "80"))
+	Jobs.Register(&httpService{port}, "http")
+}
+
+type httpService struct {
+	port string
+}
+
+func (s *httpService) Name() string {
+	return fmt.Sprintf("http[%s]:%s",
+		strings.Join(HttpHandlers.Names(), ","), s.port)
+}
+
+func (s *httpService) Setup() error {
+	for name, handler := range HttpHandlers.All() {
+		h := handler()
+		http.Handle("/"+name, h)
+		http.Handle("/"+name+"/", h)
+	}
+	return nil
+}
+
+func (s *httpService) Run() error {
+	return http.ListenAndServe(":"+s.port, nil)
+}

--- a/router/types.go
+++ b/router/types.go
@@ -1,4 +1,4 @@
-//go:generate go-extpoints . AdapterFactory HttpHandler AdapterTransport
+//go:generate go-extpoints . AdapterFactory HttpHandler AdapterTransport LogRouter Job
 package router
 
 import (
@@ -12,7 +12,7 @@ import (
 )
 
 // Extension type for adding HTTP endpoints
-type HttpHandler func(routes *RouteManager, router LogRouter) http.Handler
+type HttpHandler func() http.Handler
 
 // Extension type for adding new log adapters
 type AdapterFactory func(route *Route) (LogAdapter, error)
@@ -25,6 +25,12 @@ type AdapterTransport interface {
 // LogAdapters are streamed logs
 type LogAdapter interface {
 	Stream(logstream chan *Message)
+}
+
+type Job interface {
+	Run() error
+	Setup() error
+	Name() string
 }
 
 // LogRouters send logs to LogAdapters via Routes
@@ -58,6 +64,7 @@ type Route struct {
 	Adapter       string            `json:"adapter"`
 	Address       string            `json:"address"`
 	Options       map[string]string `json:"options,omitempty"`
+	adapter       LogAdapter
 	closer        chan bool
 	closerRcv     <-chan bool // used instead of closer when set
 }

--- a/routesapi/routesapi.go
+++ b/routesapi/routesapi.go
@@ -15,7 +15,8 @@ func init() {
 	router.HttpHandlers.Register(RoutesAPI, "routes")
 }
 
-func RoutesAPI(routes *router.RouteManager, pump router.LogRouter) http.Handler {
+func RoutesAPI() http.Handler {
+	routes := router.Routes
 	r := mux.NewRouter()
 
 	r.HandleFunc("/routes/{id}", func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
looks something like this now:
```
# logspout dev by gliderlabs
# adapters: raw udp tcp syslog
# options : debug:true persist:/mnt/routes
# jobs    : http[routes,logs]:80 pump
# routes  :
#   ADAPTER	ADDRESS			CONTAINERS	SOURCES	OPTIONS
#   syslog+tcp	172.17.0.157:9000				map[]
2015/03/30 17:56:21 pump: d71a4251163d started
2015/03/30 17:56:21 pump: f97c4f60848a ignored: environ ignore
2015/03/30 17:56:21 pump: 14c59eeb746c started
2015/03/30 17:56:21 pump: 25234c829f7a started
```