### PR TITLE
Add ONBUILD to build custom modules, fixes #69

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ EXPOSE 8000
 
 COPY . /go/src/github.com/gliderlabs/logspout
 ONBUILD COPY ./modules.go /go/src/github.com/gliderlabs/logspout/modules.go
-RUN apk-install go git mercurial \
+ONBUILD RUN apk-install go git mercurial \
 	&& cd /go/src/github.com/gliderlabs/logspout \
 	&& export GOPATH=/go \
 	&& go get \


### PR DESCRIPTION
This should make the custom module functionality work as intended.