### PR TITLE
Initialize Route options map

### DIFF
--- a/router/routes.go
+++ b/router/routes.go
@@ -83,6 +83,7 @@ func (rm *RouteManager) AddFromUri(uri string) error {
 	r := &Route{
 		Address: u.Host,
 		Adapter: u.Scheme,
+		Options: make(map[string]string),
 	}
 	if u.RawQuery != "" {
 		params, err := url.ParseQuery(u.RawQuery)


### PR DESCRIPTION
This addresses Issue #75 

The Route Options map is not initialized, so developing like so

```
DEBUG=1 ROUTE=kafka://broker1:9092?topic=hello make dev
```

Causes the following

```
Successfully built 833cbf6e10d2
# logspout dev by gliderlabs
# adapters: syslog kafka raw udp tcp
# options : debug:true persist:/mnt/routes
panic: runtime error: assignment to entry in nil map

goroutine 16 [running]:
runtime.panic(0x7f6e40, 0xa92613)
        /usr/lib/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/gliderlabs/logspout/router.(*RouteManager).AddFromUri(0xc208022de0, 0x7fff9333cf96, 0x1d, 0x0, 0x0)
        /go/src/github.com/gliderlabs/logspout/router/routes.go:102 +0x4b3
github.com/gliderlabs/logspout/router.(*RouteManager).Setup(0xc208022de0, 0x0, 0x0)
        /go/src/github.com/gliderlabs/logspout/router/routes.go:184 +0x1bb
main.main()
        /go/src/github.com/gliderlabs/logspout/logspout.go:39 +0x646
etc...
```
