### PR TITLE
UDP message delivery should not kill the program.

### DIFF
--- a/adapters/raw/raw.go
+++ b/adapters/raw/raw.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"reflect"
 	"text/template"
 
 	"github.com/gliderlabs/logspout/router"
@@ -57,7 +58,9 @@ func (a *RawAdapter) Stream(logstream chan *router.Message) {
 		_, err = a.conn.Write(buf.Bytes())
 		if err != nil {
 			log.Println("raw:", err)
-			return
+			if reflect.TypeOf(a.conn).String() != "*net.UDPConn" {
+				return
+			}
 		}
 	}
 }

--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -8,6 +8,7 @@ import (
 	"log/syslog"
 	"net"
 	"os"
+	"reflect"
 	"text/template"
 	"time"
 
@@ -89,7 +90,9 @@ func (a *SyslogAdapter) Stream(logstream chan *router.Message) {
 		_, err = a.conn.Write(buf)
 		if err != nil {
 			log.Println("syslog:", err)
-			return
+			if reflect.TypeOf(a.conn).String() != "*net.UDPConn" {
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
This addresses one of the issues mentionned in gliderlabs/logspout#79.

Currently, adapters' Stream() function returned whenever writing to the socket failed. This is not required for UDP connections. I don't quite have enough time on my hand to study the issue for TCP connections.