### PR TITLE
HTTP transport with configurable buffering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ dev:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(PWD):/go/src/github.com/gliderlabs/logspout \
 		-p 8000:80 \
-		-e ROUTE_URIS=$(ROUTE) \
+		-e ROUTE_URIS="$(ROUTE)" \
+		-e LOGSPOUT=ignore \
 		$(NAME):dev
 
 build:

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v3-master
+v3-raychaser-http-buffered

--- a/adapters/http/README.md
+++ b/adapters/http/README.md
@@ -1,0 +1,107 @@
+# HTTP Adapter
+
+
+### Usage
+
+The route URI for an HTTP/HTTPS point endpoint should just include the hostname. The HTTP path currently has to specified as a parameter. For example, for Sumo Logic the endpoint URI with for an HTTP collector endpoint would look like this:
+
+```
+https://collectors.sumologic.com/receiver/v1/http/SUMO_HTTP_TOKEN
+```
+
+But for Logspout, it needs to be written like this:
+
+```
+https://collectors.sumologic.com?http.path=/receiver/v1/http/SUMO_HTTP_TOKEN
+```
+
+The HTTP adapter also supports 2 parameters to control the buffer capacity and timeout used to determine when the buffer is being flushed if the capacity of the buffer isn't reached in time. The default values are 100 for the buffer capacity and 1000ms for the timeout. The parameters are specified in the URI. For example, to change the timeout to 30 seconds, and make a buffer of only 5 messages, use this URI.
+
+```
+https://collectors.sumologic.com?http.path=/receiver/v1/http/SUMO_HTTP_TOKEN\&http.buffer.timeout=30s\&http.buffer.capacity=5
+```
+
+
+### Development 
+
+This assumes that the unique token for the Sumo Logic HTTP collector endpoint is in the environment as ```$SUMO_HTTP_TOKEN```.
+
+```bash
+$ DEBUG=1 \ 
+   ROUTE=https://collectors.sumologic.com?http.buffer.timeout=30s\&http.buffer.capacity=5\&http.path=/receiver/v1/http/$SUMO_HTTP_TOKEN \
+   make dev
+```
+
+To create some test messages
+
+```bash
+$ docker run --rm -i --name test1 ubuntu bash -c 'NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1); for i in `seq 1 10`; do echo $NEW_UUID Hello $i; sleep 1; done'
+```
+
+
+### Todos
+
+- [ ] Deal with errors and non-200 responses... somehow
+- [ ] Make sure we send back the AWS ELB cookie if we get one
+- [ ] Add compression option
+
+
+
+### Issues Found While Writing This Adapter
+
+Log of stuff I ran into to verify, validate, discuss, fix, ...
+
+* Cannot figure out how to create a "custom" build from my own source code
+* Full URL is not passed as part of Route, so Sumo-style endpoint URL where the path is relevant and includes auth info isn't working
+* Uninitialized options map when using non-standard parameter (#75, #76)
+* Logspout seems to need ```-e LOGSPOUT=ignore``` to prevent getting into a feedback loop when using debug output - need to validate this feedback loop is a universal possibility or just something i backed myself into
+* Makefile needs quotes around ```$(ROUTE)``` if URL includes ampersand, and ampersand needs to be quoted
+```bash
+$ DEBUG=1 \
+    ROUTE=https://collectors.sumologic.com?http.buffer.timeout=30s\& make dev
+```
+* Docker 1.6 with ```--log-driver=none``` or ```--log-driver=syslog``` will break Logspout
+
+
+
+### Issue With --log-driver In Docker 1.6
+
+Just writing this down here for now so I don't lose it... Likely should be discussed in the Docker context, not the Logspout context. Logspout will not see any container output if the ```--log-driver``` (new in Docker 1.6) is set to anything but the default (```json-file```). Proof:
+
+```bash
+$ docker run --rm -it --name test1 ubuntu bash -c 'NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1); for i in `seq 1 10000`; do echo $NEW_UUID Hello $i; sleep 1; done'
+$ CID=$(docker ps -l -q)
+$ echo -e "GET /containers/c4074eb48952/logs?stdout=1 HTTP/1.0\r\n" | nc -U /var/run/docker.sock
+```
+
+This should return the the logs of the started container.
+
+```bash
+$ docker stop $CID
+$ docker run --rm -it --log-driver=syslog --name test1 ubuntu bash -c 'NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1); for i in `seq 1 10000`; do echo $NEW_UUID Hello $i; sleep 1; done'
+$ CID=$(docker ps -l -q)
+$ echo -e "GET /containers/c4074eb48952/logs?stdout=1 HTTP/1.0\r\n" | nc -U /var/run/docker.sock
+```
+
+Will return:
+
+```
+"logs" endpoint is supported only for "json-file" logging driver
+Error running logs job: "logs" endpoint is supported only for "json-file" logging driver
+```
+
+This is unfortunate because it prevents using --log-driver=none in conjunction with Logspout to forward logs without touching the host disk. With ```json-file``` being required, the issue of logs running the host of disk space still remains.
+
+
+### Using The Image From Docker Hub
+
+This again assumes that the unique token for the Sumo Logic HTTP collector endpoint is in the environment as ```$SUMO_HTTP_TOKEN```.
+
+```bash
+$ docker run -e DEBUG=1 \
+    -v=/var/run/docker.sock:/var/run/docker.sock \
+	raychaser/logspout:latest-http-buffered \   
+	https://collectors.sumologic.com?http.buffer.timeout=1s\&http.buffer.capacity=100\&http.path=/receiver/v1/http/$SUMO_HTTP_TOKEN
+```
+
+

--- a/adapters/http/http.go
+++ b/adapters/http/http.go
@@ -1,0 +1,272 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gliderlabs/logspout/router"
+)
+
+func init() {
+	router.AdapterFactories.Register(NewHTTPAdapter, "http")
+	router.AdapterFactories.Register(NewHTTPAdapter, "https")
+}
+
+func debug(v ...interface{}) {
+	if os.Getenv("DEBUG") != "" {
+		log.Println(v...)
+	}
+}
+
+func die(v ...interface{}) {
+	panic(fmt.Sprintln(v...))
+}
+
+func getopt(name, dfault string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		value = dfault
+	}
+	return value
+}
+
+func getStringParameter(
+	options map[string]string, parameterName string, dfault string) string {
+
+	if value, ok := options[parameterName]; ok {
+		return value
+	} else {
+		return dfault
+	}
+}
+
+func getIntParameter(
+	options map[string]string, parameterName string, dfault int) int {
+
+	if value, ok := options[parameterName]; ok {
+		valueInt, err := strconv.Atoi(value)
+		if err != nil {
+			debug("http: invalid value for parameter:", parameterName, value)
+			return dfault
+		} else {
+			return valueInt
+		}
+	} else {
+		return dfault
+	}
+}
+
+func getDurationParameter(
+	options map[string]string, parameterName string,
+	dfault time.Duration) time.Duration {
+
+	if value, ok := options[parameterName]; ok {
+		valueDuration, err := time.ParseDuration(value)
+		if err != nil {
+			debug("http: invalid value for parameter:", parameterName, value)
+			return dfault
+		} else {
+			return valueDuration
+		}
+	} else {
+		return dfault
+	}
+}
+
+func dial(netw, addr string) (net.Conn, error) {
+	dial, err := net.Dial(netw, addr)
+	if err != nil {
+		debug("http: new dial", dial, err, netw, addr)
+	} else {
+		debug("http: new dial", dial, netw, addr)
+	}
+	return dial, err
+}
+
+// HTTPAdapter is an adapter that POSTs logs to an HTTP endpoint
+type HTTPAdapter struct {
+	route             *router.Route
+	url               string
+	client            *http.Client
+	buffer            []*router.Message
+	timer             *time.Timer
+	capacity          int
+	timeout           time.Duration
+	totalMessageCount int
+	bufferMutex       sync.Mutex
+}
+
+// NewHTTPAdapter creates an HTTPAdapter
+func NewHTTPAdapter(route *router.Route) (router.LogAdapter, error) {
+
+	// Figure out the URI and create the HTTP client
+	defaultPath := ""
+	path := getStringParameter(route.Options, "http.path", defaultPath)
+	url := fmt.Sprintf("%s://%s%s", route.Adapter, route.Address, path)
+	debug("http: url:", url)
+	transport := &http.Transport{}
+	transport.Dial = dial
+	client := &http.Client{Transport: transport}
+
+	// Determine the buffer capacity
+	defaultCapacity := 100
+	capacity := getIntParameter(
+		route.Options, "http.buffer.capacity", defaultCapacity)
+	if capacity < 1 || capacity > 10000 {
+		debug("http: non-sensical value for parameter: http.buffer.capacity",
+			capacity, "using default:", defaultCapacity)
+		capacity = defaultCapacity
+	}
+	buffer := make([]*router.Message, 0, capacity)
+
+	// Determine the buffer timeout
+	defaultTimeout, _ := time.ParseDuration("1000ms")
+	timeout := getDurationParameter(
+		route.Options, "http.buffer.timeout", defaultTimeout)
+	timeoutSeconds := timeout.Seconds()
+	if timeoutSeconds < .1 || timeoutSeconds > 600 {
+		debug("http: non-sensical value for parameter: http.buffer.timeout",
+			timeout, "using default:", defaultTimeout)
+		timeout = defaultTimeout
+	}
+	timer := time.NewTimer(timeout)
+
+	// Make the HTTP adapter
+	return &HTTPAdapter{
+		route:    route,
+		url:      url,
+		client:   client,
+		buffer:   buffer,
+		timer:    timer,
+		capacity: capacity,
+		timeout:  timeout,
+	}, nil
+}
+
+// Stream implements the router.LogAdapter interface
+func (a *HTTPAdapter) Stream(logstream chan *router.Message) {
+	for {
+		select {
+		case message := <-logstream:
+
+			// Append the message to the buffer
+			a.bufferMutex.Lock()
+			a.buffer = append(a.buffer, message)
+			a.bufferMutex.Unlock()
+
+			// Flush if the buffer is at capacity
+			if len(a.buffer) >= cap(a.buffer) {
+				a.flushHttp("full")
+			}
+		case <-a.timer.C:
+
+			// Flush if there's anything in the buffer
+			if len(a.buffer) > 0 {
+				a.flushHttp("timeout")
+			}
+		}
+	}
+}
+
+// Flushes the accumulated messages in the buffer
+func (a *HTTPAdapter) flushHttp(reason string) {
+
+	// Stop the timer and drain any possible remaining events
+	a.timer.Stop()
+	select {
+	case <-a.timer.C:
+	default:
+	}
+
+	// Reset the timer when we are done
+	defer a.timer.Reset(a.timeout)
+
+	// Capture the buffer and make a new one
+	a.bufferMutex.Lock()
+	buffer := a.buffer
+	a.buffer = make([]*router.Message, 0, a.capacity)
+	a.bufferMutex.Unlock()
+
+	// Create JSON representation of all messages
+	messages := make([]string, 0, len(buffer))
+	for i := range buffer {
+		m := buffer[i]
+		httpMessage := HTTPMessage{
+			Message:  m.Data,
+			Time:     m.Time.Format(time.RFC3339),
+			Source:   m.Source,
+			Name:     m.Container.Name,
+			ID:       m.Container.ID,
+			Image:    m.Container.Config.Image,
+			Hostname: m.Container.Config.Hostname,
+		}
+		message, err := json.Marshal(httpMessage)
+		if err != nil {
+			debug("flushHttp - Error encoding JSON: ", err)
+			continue
+		}
+		messages = append(messages, string(message))
+	}
+
+	// Glue all the JSON representations together into one payload to send
+	payload := strings.Join(messages, "\n")
+
+	go func() {
+
+		// Send the payload.
+		request, err := http.NewRequest(
+			"POST", a.url, strings.NewReader(payload))
+		if err != nil {
+			debug("http: error on http.NewRequest:", err, a.url)
+			// TODO @raychaser - now what?
+			die("", "http: error on http.NewRequest:", err, a.url)
+		}
+		start := time.Now()
+		response, err := a.client.Do(request)
+		if err != nil {
+			debug("http - error on client.Do:", err, a.url)
+			// TODO @raychaser - now what?
+			die("http - error on client.Do:", err, a.url)
+		}
+		if response.StatusCode != 200 {
+			debug("http: response not 200 but", response.StatusCode)
+			// TODO @raychaser - now what?
+			die("http: response not 200 but", response.StatusCode)
+		}
+
+		// Make sure the entire response body is read so the HTTP
+		// connection can be reused
+		io.Copy(ioutil.Discard, response.Body)
+		response.Body.Close()
+
+		//		debug(fmt.Sprintf("%#v", request.TLS))
+		//		debug(fmt.Sprintf("%#v", response))
+
+		// Bookkeeping, logging
+		timeAll := time.Since(start)
+		a.totalMessageCount += len(messages)
+		debug("http: flushed:", reason, "messages:", len(messages),
+			"in:", timeAll, "total:", a.totalMessageCount)
+	}()
+}
+
+// HTTPMessage is a simple JSON representation of the log message.
+type HTTPMessage struct {
+	Message  string `json:"message"`
+	Time     string `json:"time"`
+	Source   string `json:"source"`
+	Name     string `json:"docker.name"`
+	ID       string `json:"docker.id"`
+	Image    string `json:"docker.image"`
+	Hostname string `json:"docker.hostname"`
+}

--- a/adapters/http/http.go
+++ b/adapters/http/http.go
@@ -170,10 +170,8 @@ func (a *HTTPAdapter) Stream(logstream chan *router.Message) {
 			}
 		case <-a.timer.C:
 
-			// Flush if there's anything in the buffer
-			if len(a.buffer) > 0 {
-				a.flushHttp("timeout")
-			}
+			// Timeout, flush
+			a.flushHttp("timeout")
 		}
 	}
 }
@@ -190,6 +188,11 @@ func (a *HTTPAdapter) flushHttp(reason string) {
 
 	// Reset the timer when we are done
 	defer a.timer.Reset(a.timeout)
+
+	// Return immediately if the buffer is empty
+	if len(a.buffer) < 1 {
+		return
+	}
 
 	// Capture the buffer and make a new one
 	a.bufferMutex.Lock()

--- a/modules.go
+++ b/modules.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "github.com/gliderlabs/logspout/adapters/http"
 	_ "github.com/gliderlabs/logspout/adapters/raw"
 	_ "github.com/gliderlabs/logspout/adapters/syslog"
 	_ "github.com/gliderlabs/logspout/httpstream"

--- a/router/routes.go
+++ b/router/routes.go
@@ -83,6 +83,7 @@ func (rm *RouteManager) AddFromUri(uri string) error {
 	r := &Route{
 		Address: u.Host,
 		Adapter: u.Scheme,
+		Options: make(map[string]string),
 	}
 	if u.RawQuery != "" {
 		params, err := url.ParseQuery(u.RawQuery)


### PR DESCRIPTION
Among other things, in response to #56.

This adds an adapter that sends logs to an HTTP(S) endpoint via POST. To prevent round-trip madness, the adapter buffers mesages and sends them only when the buffer is full (default buffer capacity: 100 messages), or a configurable timeout has been reached (default: 1 second). I took some care to make sure keep-alive is honored, so this should be reasonably efficient.

Tested against Sumo Logic with a good amount of concurrent load, but this should work against any HTTP-ish endpoint. Of course, this is very much an initial implementation that likely can be much improved.

`adapters/http/README.md` has some more details, and an initial TODO list.

This includes the fix for #75 from #76.

Also, I am not at all sure whether I am doing the right thing with the VERSION file!

@progrium, there's an "Issue found" section in the README that I would be happy to discuss either as part of the PR, or on IRC (i am `raychas3r`, usually in PDT)

@dylanmei, FYI.