### PR TITLE
If log driver is not 'json-file' use /attach API to get the log stream

### DIFF
--- a/router/pump.go
+++ b/router/pump.go
@@ -63,6 +63,10 @@ func ignoreContainer(container *docker.Container) bool {
 	return false
 }
 
+func hasJsonFile(container *docker.Container) bool {
+	return container.HostConfig.LogConfig.Type == "json-file"
+}
+
 type update struct {
 	*docker.APIEvents
 	pump *containerPump
@@ -143,15 +147,31 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool) {
 	p.update(event)
 	debug("pump:", id, "started")
 	go func() {
-		err := p.client.Logs(docker.LogsOptions{
-			Container:    id,
-			OutputStream: outwr,
-			ErrorStream:  errwr,
-			Stdout:       true,
-			Stderr:       true,
-			Follow:       true,
-			Tail:         tail,
-		})
+		var err error
+		// Log drivers other than 'json-file' will not support the /logs API
+		if hasJsonFile(container) {
+			debug("pump:", id, "using /logs")
+			err = p.client.Logs(docker.LogsOptions{
+				Container:    id,
+				OutputStream: outwr,
+				ErrorStream:  errwr,
+				Stdout:       true,
+				Stderr:       true,
+				Follow:       true,
+				Tail:         tail,
+			})
+		} else {
+			debug("pump:", id, "using /attach")
+			err = p.client.AttachToContainer(docker.AttachToContainerOptions{
+				Container:    id,
+				OutputStream: outwr,
+				ErrorStream:  errwr,
+				Stdout:       true,
+				Stderr:       true,
+				Logs:         false,
+				Stream:       true,
+			})
+		}
 		if err != nil {
 			debug("pump:", id, "stopped:", err)
 		}


### PR DESCRIPTION
I really want to use Logspout without having to go to disk for the logs. I thought I needed to fix this on the Docker side, but [the discussion brought about the idea](https://github.com/docker/docker/pull/12790) to use the `/attach` API in order to at least get a live stream of logs when the log driver is not `json-file`. Any other log driver disables the `/logs` endpoint, but with this patch I can run `--log-driver=none` and still forward logs via Logspout. 

It would appear that there is a race condition: between Logspout getting the (re)start event and actually attaching to the container the container could have outputted logs already. But in my tests so far this actually didn't really happen.