### PR TITLE
Fix port number in httpstream example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Using the [httpstream module](http://github.com/gliderlabs/logspout/blob/master/
 
 	$ docker run -d --name="logspout" \
 		--volume=/var/run/docker.sock:/tmp/docker.sock \
-		--publish=127.0.0.1:8000:8000 \
+		--publish=127.0.0.1:8000:80 \
 		gliderlabs/logspout
 	$ curl http://127.0.0.1:8000/logs
 


### PR DESCRIPTION
The internal port is [80](https://github.com/gliderlabs/logspout/blob/2bd141a23632fce6aeca99f98bf7d51c3956612f/router/http.go#L10), not 8000.