### PR TITLE
Adds a .Env function on syslog messages

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -8,6 +8,7 @@ import (
 	"log/syslog"
 	"net"
 	"os"
+	"strings"
 	"text/template"
 	"time"
 
@@ -215,4 +216,14 @@ func (m *SyslogMessage) Timestamp() string {
 
 func (m *SyslogMessage) ContainerName() string {
 	return m.Message.Container.Name[1:]
+}
+
+func (m *SyslogMessage) Env(key string) string {
+	envValues := m.Message.Container.Config.Env
+	for _, env := range envValues {
+		if strings.HasPrefix(env, key+"=") {
+			return env[len(key)+1:]
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
I know the usual method to do changes like this is rolling a custom logspout container with our modified syslog adapter module, but I thought this change might be generally useful.

We've run into the issue where we want to add some container specific information to our log lines, but don't have control of either the container hostname or container name (we are on mesos/marathon).  Allowing using container environment variables in the syslog configuration templates (i.e. SYSLOG_TAG) allows us to pull in this custom info.
