### PR TITLE
allow to force-set black background of httpstream output

### DIFF
--- a/httpstream/README.md
+++ b/httpstream/README.md
@@ -10,5 +10,5 @@ You can select specific log types from a source using a comma-delimited list in 
 
 If you include a request `Accept: application/json` header, the output will be JSON objects. Note that when upgrading to WebSocket, it will always use JSON.
 
-Since `/logs` and `/logs/name:<string>` endpoints can return logs from multiple containers, they will by default return color-coded loglines prefixed with the name of the container. You can turn off the color escape codes with query param `colors=off` or the alternative is to stream the data in JSON format, which won't use colors or prefixes.
+Since `/logs` and `/logs/name:<string>` endpoints can return logs from multiple containers, they will by default return color-coded loglines prefixed with the name of the container. If your default terminal background is white and the colored text is unreadable, you can force-set black background with query param 'background=black'. You can turn off the color escape codes with query param `colors=off` or the alternative is to stream the data in JSON format, which won't use colors or prefixes. 
 

--- a/httpstream/httpstream.go
+++ b/httpstream/httpstream.go
@@ -117,10 +117,14 @@ func websocketStreamer(w http.ResponseWriter, req *http.Request, logstream chan 
 func httpStreamer(w http.ResponseWriter, req *http.Request, logstream chan *router.Message, multi bool) {
 	var colors Colorizer
 	var usecolor, usejson bool
+	var backgroundcolor string
 	nameWidth := 16
 	if req.URL.Query().Get("colors") != "off" {
 		colors = make(Colorizer)
 		usecolor = true
+	}
+	if req.URL.Query().Get("background") == "black" {
+		backgroundcolor = "\x1b[40m"
 	}
 	if req.Header.Get("Accept") == "application/json" {
 		w.Header().Add("Content-Type", "application/json")
@@ -142,8 +146,8 @@ func httpStreamer(w http.ResponseWriter, req *http.Request, logstream chan *rout
 				}
 				if usecolor {
 					w.Write([]byte(fmt.Sprintf(
-						"%s%"+strconv.Itoa(nameWidth)+"s|%s\x1b[0m\n",
-						colors.Get(name), name, logline.Data,
+						"%s%s%"+strconv.Itoa(nameWidth)+"s|%s\x1b[0m\n",
+						backgroundcolor, colors.Get(name), name, logline.Data,
 					)))
 				} else {
 					w.Write([]byte(fmt.Sprintf(


### PR DESCRIPTION
On white or bright-grey terminal, it's very difficult to read the color of httpstream ouput. I added an optional query param backgroud=black which will force-set the terminal background of the httpstream output text to black.
