### PR TITLE
Allow populating cached routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The simplest way to use logspout is to just take all logs and ship to a remote s
 		gliderlabs/logspout \
 		syslog://logs.papertrailapp.com:55555
 
-logspout will gather logs from other containers that are started **without the `-t` option**. 
+logspout will gather logs from other containers that are started **without the `-t` option**.
 
 To see what data is used for syslog messages, see the [syslog adapter](http://github.com/gliderlabs/logspout/blob/master/adapters) docs.
 
@@ -66,6 +66,21 @@ That example creates a new syslog route to [Papertrail](https://papertrailapp.co
 Routes are stored on disk, so by default routes are ephemeral. You can mount a volume to `/mnt/routes` to persist them.
 
 See [routesapi module](http://github.com/gliderlabs/logspout/blob/master/routesapi) for all options.
+
+#### Precache routes via environmental variable
+
+You can set the environmental variable for the container PRECACHE_ROUTES to be an array of routes. Each route will be persisted to disk and used on startup instead of relying on the persistence of an attached volume / mnt or updating via the logspout API.
+
+The routes need to contain an id. Ex:
+	[
+	    {
+	        "id": "3631c027fb1b",
+	        "filter_name": "mycontainer",
+	        "adapter": "syslog",
+	        "address": "192.168.1.111:514"
+	    }
+	]
+
 
 ## Modules
 

--- a/router/persist.go
+++ b/router/persist.go
@@ -58,6 +58,17 @@ func (fs RouteFileStore) Remove(id string) bool {
 	return false
 }
 
+func (fs RouteFileStore) PreCacheRoutes(preCacheRoutes string) {
+	var routes *[]Route
+	b := []byte(preCacheRoutes)
+	if err := json.Unmarshal(b, &routes) {
+		return err
+	}
+	for _, route := range routes {
+		fs.Add(route)
+	}
+}
+
 func marshal(obj interface{}) []byte {
 	bytes, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {

--- a/router/persist.go
+++ b/router/persist.go
@@ -58,15 +58,16 @@ func (fs RouteFileStore) Remove(id string) bool {
 	return false
 }
 
-func (fs RouteFileStore) PreCacheRoutes(preCacheRoutes string) {
-	var routes *[]Route
+func (fs RouteFileStore) PreCacheRoutes(preCacheRoutes string) error {
+	routes := &[]Route{}
 	b := []byte(preCacheRoutes)
-	if err := json.Unmarshal(b, &routes) {
+	if err := json.Unmarshal(b, &routes); err != nil {
 		return err
 	}
-	for _, route := range routes {
-		fs.Add(route)
+	for _, route := range *routes {
+		fs.Add(&route)
 	}
+	return nil
 }
 
 func marshal(obj interface{}) []byte {

--- a/router/routes.go
+++ b/router/routes.go
@@ -190,9 +190,15 @@ func (rm *RouteManager) Setup() error {
 		}
 	}
 
+	preCacheRoutes := getopt("PRECACHE_ROUTES", "")
+
 	persistPath := getopt("ROUTESPATH", "/mnt/routes")
 	if _, err := os.Stat(persistPath); err == nil {
-		return rm.Load(RouteFileStore(persistPath))
+		persistor := RouteFileStore(persistPath)
+		if preCacheRoutes != "" {
+			persistor.PreCacheRoutes(preCacheRoutes)
+		}
+		return rm.Load(persistor)
 	}
 	return nil
 }


### PR DESCRIPTION
I had an instance where I wanted to fill out multiple routes for a container dynamically and didn't want a new container repo every time and didn't want to mount a volume for configuration to it. This solved the problem for it's startup - we've since moved away from this solution but I wanted to send the PR back to the mainline to see if it was wanted.