### PR TITLE
Docker sock mount read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can also download and load a specific version:
 The simplest way to use logspout is to just take all logs and ship to a remote syslog. Just pass a syslog URI (or several comma separated URIs) as the command. Also, we always mount the Docker Unix socket with `-v` to `/tmp/docker.sock`:
 
 	$ docker run --name="logspout" \
-		--volume=/var/run/docker.sock:/tmp/docker.sock \
+		--volume=/var/run/docker.sock:/tmp/docker.sock:ro \
 		gliderlabs/logspout \
 		syslog://logs.papertrailapp.com:55555
 
@@ -44,7 +44,7 @@ You can tell logspout to ignore specific containers by setting an environment va
 Using the [httpstream module](http://github.com/gliderlabs/logspout/blob/master/httpstream), you can connect with curl to see your local aggregated logs in realtime. You can do this without setting up a route URI.
 
 	$ docker run -d --name="logspout" \
-		--volume=/var/run/docker.sock:/tmp/docker.sock \
+		--volume=/var/run/docker.sock:/tmp/docker.sock:ro \
 		--publish=127.0.0.1:8000:80 \
 		gliderlabs/logspout
 	$ curl http://127.0.0.1:8000/logs


### PR DESCRIPTION
Recommend mounting /var/run/docker.sock as read-only for increased security.