### PR TITLE
Allow Docker label to be used to ignore containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ You can tell logspout to ignore specific containers by setting an environment va
 
         $ docker run -d -e 'LOGSPOUT=ignore' image
 
-Alternatively, can use the Docker label 'com.gliderlabs.logspout.ignore=true' to ignore containers.
+Alternatively, can use the Docker label 'logspout.ignore=true' to ignore containers.
 
-        $ docker run -d -l 'com.gliderlabs.logspout.ignore=true' image
+        $ docker run -d -l 'logspout.ignore=true' image
 
 #### Inspect log streams using curl
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ You can tell logspout to ignore specific containers by setting an environment va
 
         $ docker run -d -e 'LOGSPOUT=ignore' image
 
+Alternatively, can use the Docker label 'com.gliderlabs.logspout.ignore=true' to ignore containers.
+
+        $ docker run -d -l 'com.gliderlabs.logspout.ignore=true' image
+
 #### Inspect log streams using curl
 
 Using the [httpstream module](http://github.com/gliderlabs/logspout/blob/master/httpstream), you can connect with curl to see your local aggregated logs in realtime. You can do this without setting up a route URI.

--- a/router/pump.go
+++ b/router/pump.go
@@ -60,6 +60,12 @@ func ignoreContainer(container *docker.Container) bool {
 			return true
 		}
 	}
+
+	if value, ok := container.Config.Labels["com.gliderlabs.logspout.ignore"]; ok {
+		if strings.ToLower(value) == "true" {
+			return true
+		}
+	}
 	return false
 }
 
@@ -126,7 +132,7 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool) {
 		return
 	}
 	if ignoreContainer(container) {
-		debug("pump:", id, "ignored: environ ignore")
+		debug("pump:", id, "ignored: container specified ignore")
 		return
 	}
 	var tail string

--- a/router/pump.go
+++ b/router/pump.go
@@ -61,7 +61,7 @@ func ignoreContainer(container *docker.Container) bool {
 		}
 	}
 
-	if value, ok := container.Config.Labels["com.gliderlabs.logspout.ignore"]; ok {
+	if value, ok := container.Config.Labels["logspout.ignore"]; ok {
 		if strings.ToLower(value) == "true" {
 			return true
 		}


### PR DESCRIPTION
This change allows a user to set a Docker label `com.gliderlabs.logspout.ignore=true` to have Logspout ignore the container for log processing. I took the liberty of proposing the namespace based on Docker's documentation. If there is something else that should be used please let me know. I didn't see any previous label support.
