### PR TITLE
Use correct nilvalue for structured data as per rfc 5424

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -51,10 +51,16 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 	}
 	data := getopt("SYSLOG_DATA", "{{.Data}}")
 
+	if structuredData == "" {
+		structuredData = "-"
+	} else {
+		structuredData = fmt.Sprintf("[%s]", structuredData)
+	}
+
 	var tmplStr string
 	switch format {
 	case "rfc5424":
-		tmplStr = fmt.Sprintf("<%s>1 {{.Timestamp}} %s %s %s - [%s] %s\n",
+		tmplStr = fmt.Sprintf("<%s>1 {{.Timestamp}} %s %s %s - %s %s\n",
 			priority, hostname, tag, pid, structuredData, data)
 	case "rfc3164":
 		tmplStr = fmt.Sprintf("<%s>{{.Timestamp}} %s %s[%s]: %s\n",


### PR DESCRIPTION
Thanks to Troy at Papertrail for spotting this.

As per RFC 5424:

>STRUCTURED-DATA can contain zero, one, or multiple structured data
>elements, which are referred to as "SD-ELEMENT" in this document.
>
>In case of zero structured data elements, the STRUCTURED-DATA field
>MUST contain the NILVALUE.

NILVALUE being `-`