### PR TITLE
Add link to third-party module logspout-fluentd

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The standard distribution of logspout comes with all modules defined in this rep
  * logspout-kafka...
  * logspout-redis...
  * [logspout-logstash](https://github.com/looplab/logspout-logstash)
+ * [logspout-fluentd](https://github.com/infusionsoft/logspout-fluentd-module)
 
 ## Contributing
 


### PR DESCRIPTION
I just built a logspout module for fluentd at https://github.com/infusionsoft/logspout-fluentd-module.

It includes support for sending Docker labels to fluentd (or really any arbitrary UDP listener that accepts JSON).