### PR TITLE
Syslog: Re-establish TCP/TLS transport on connection interruptions

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"sync"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -68,15 +70,37 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 	}
 	return &SyslogAdapter{
 		route: route,
+		trnsp: transport,
 		conn:  conn,
 		tmpl:  tmpl,
 	}, nil
 }
 
 type SyslogAdapter struct {
+	mu    sync.Mutex
 	conn  net.Conn
+	trnsp router.AdapterTransport
 	route *router.Route
 	tmpl  *template.Template
+}
+
+func (a *SyslogAdapter) maybeReconnect(writeErr error) bool {
+	nErr, ok := writeErr.(*net.OpError)
+	if !ok || (!nErr.Temporary() && nErr.Err != syscall.EPIPE) {
+		return false
+	}
+	time.Sleep(500 * time.Millisecond)
+	conn, err := a.trnsp.Dial(a.route.Address, a.route.Options)
+	if err != nil {
+		log.Println("syslog:", err)
+		return false
+	}
+
+	a.mu.Lock()
+	a.conn.Close()
+	a.conn = conn
+	a.mu.Unlock()
+	return true
 }
 
 func (a *SyslogAdapter) Stream(logstream chan *router.Message) {
@@ -91,7 +115,9 @@ func (a *SyslogAdapter) Stream(logstream chan *router.Message) {
 		if err != nil {
 			log.Println("syslog:", err)
 			if reflect.TypeOf(a.conn).String() != "*net.UDPConn" {
-				return
+				if ok := a.maybeReconnect(err); !ok {
+					return
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes issue #107 where logspout indefinitely stops sending syslog messages when the connection is interrupted (e.g. the syslog consumer's IP address changed) and has to be manually restarted.

This establishes a new connection when a syslog write operation on a TCP/TLS transport adapter fails with a network related temporary error.