### PR TITLE
Fixes build - Add community repo and use latest go version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+echo http://dl-4.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories
 apk add --update go git mercurial
 mkdir -p /go/src/github.com/gliderlabs
 cp -r /src /go/src/github.com/gliderlabs/logspout


### PR DESCRIPTION
Build was failing when building a custom module.

```
Sending build context to Docker daemon 3.072 kB
Step 0 : FROM gliderlabs/logspout:master
# Executing 2 build triggers
Trigger 0, COPY ./modules.go /src/modules.go
Step 0 : COPY ./modules.go /src/modules.go
 ---> Using cache
Trigger 1, RUN cd /src && ./build.sh "$(cat VERSION)-custom"
Step 0 : RUN cd /src && ./build.sh "$(cat VERSION)-custom"
 ---> Running in 08559e095407
fetch http://alpine.gliderlabs.com/alpine/v3.1/main/x86_64/APKINDEX.tar.gz
(1/21) Installing go (1.3.3-r1)
(2/21) Installing run-parts (4.4-r0)
(3/21) Installing openssl (1.0.1s-r0)
(4/21) Installing lua5.2-libs (5.2.3-r0)
(5/21) Installing lua5.2 (5.2.3-r0)
(6/21) Installing lua5.2-posix (32-r1)
(7/21) Installing ca-certificates (20141019-r0)
(8/21) Installing libssh2 (1.4.3-r1)
(9/21) Installing curl (7.39.0-r0)
(10/21) Installing expat (2.1.0-r1)
(11/21) Installing pcre (8.36-r2)
(12/21) Installing git (2.2.1-r0)
(13/21) Installing libbz2 (1.0.6-r3)
(14/21) Installing libffi (3.0.13-r0)
(15/21) Installing gdbm (1.11-r0)
(16/21) Installing ncurses-terminfo-base (5.9-r3)
(17/21) Installing ncurses-libs (5.9-r3)
(18/21) Installing readline (6.3-r3)
(19/21) Installing sqlite-libs (3.8.10.2-r1)
(20/21) Installing python (2.7.9-r0)
(21/21) Installing mercurial (3.2.2-r0)
Executing busybox-1.22.1-r15.trigger
Executing ca-certificates-20141019-r0.trigger
OK: 173 MiB in 36 packages
# github.com/golang/snappy
../../golang/snappy/decode_amd64.s:6 6a: No such file or directory: textflag.h
The command '/bin/sh -c cd /src && ./build.sh "$(cat VERSION)-custom"' returned a non-zero code: 2
```

Error seems to be from using go-1.3.3-r1. Using community repo installs latest go, currently 1.6-r1.