### PR TITLE
Exclude containers by label.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or, by adding a label which you define by setting an environment variable when r
     $ docker run --name="logspout" \
         -e EXCLUDE_LABEL=logspout.exclude \
         --volume=/var/run/docker.sock:/var/run/docker.sock \
-        gliderlabs/logspout \gliderlabs/logspout
+        gliderlabs/logspout
     $ docker run -d --label logspout.exclude=true image
 
 #### Inspect log streams using curl

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ You can tell logspout to ignore specific containers by setting an environment va
 
         $ docker run -d -e 'LOGSPOUT=ignore' image
 
+Or, by adding a label:
+
+        $ docker run -d --label logspout.exclude= image
+
 #### Inspect log streams using curl
 
 Using the [httpstream module](http://github.com/gliderlabs/logspout/blob/master/httpstream), you can connect with curl to see your local aggregated logs in realtime. You can do this without setting up a route URI.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,15 @@ To see what data is used for syslog messages, see the [syslog adapter](http://gi
 
 You can tell logspout to ignore specific containers by setting an environment variable when starting your container, like so:-
 
-        $ docker run -d -e 'LOGSPOUT=ignore' image
+    $ docker run -d -e 'LOGSPOUT=ignore' image
 
-Or, by adding a label:
+Or, by adding a label which you define by setting an environment variable when running logspout:
 
-        $ docker run -d --label logspout.exclude= image
+    $ docker run --name="logspout" \
+        -e EXCLUDE_LABEL=logspout.exclude \
+        --volume=/var/run/docker.sock:/var/run/docker.sock \
+        gliderlabs/logspout \gliderlabs/logspout
+    $ docker run -d --label logspout.exclude=true image
 
 #### Inspect log streams using curl
 

--- a/router/pump.go
+++ b/router/pump.go
@@ -60,6 +60,11 @@ func ignoreContainer(container *docker.Container) bool {
 			return true
 		}
 	}
+	excludeLabel := getopt("EXCLUDE", "")
+	_, ok := container.Config.Labels[excludeLabel]
+	if ok {
+		return true
+	}
 	return false
 }
 

--- a/router/pump.go
+++ b/router/pump.go
@@ -62,7 +62,7 @@ func ignoreContainer(container *docker.Container) bool {
 	}
 	excludeLabel := getopt("EXCLUDE_LABEL", "")
 	if value, ok := container.Config.Labels[excludeLabel]; ok {
-		return strings.ToLower(value) == "true"
+		return len(excludeLabel) > 0 && strings.ToLower(value) == "true"
 	}
 	return false
 }

--- a/router/pump.go
+++ b/router/pump.go
@@ -60,10 +60,9 @@ func ignoreContainer(container *docker.Container) bool {
 			return true
 		}
 	}
-	excludeLabel := getopt("EXCLUDE", "")
-	_, ok := container.Config.Labels[excludeLabel]
-	if ok {
-		return true
+	excludeLabel := getopt("EXCLUDE_LABEL", "")
+	if value, ok := container.Config.Labels[excludeLabel]; ok {
+		return strings.ToLower(value) == "true"
 	}
 	return false
 }


### PR DESCRIPTION
This allows to ignore containers with a particular label specified by:
`docker run -e EXCLUDE=logspout.exclude gliderlabs/logspout`

This will ignore all the containers ran using `--label logspout.exclude=...` as suggested (#159)