### PR TITLE
Now using Alpine Linux 3.3 and GO 1.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.1
+FROM gliderlabs/alpine:3.3
 ENTRYPOINT ["/bin/logspout"]
 VOLUME /mnt/routes
 EXPOSE 80

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.1
+FROM gliderlabs/alpine:3.3
 VOLUME /mnt/routes
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For now it only captures stdout and stderr, but a module to collect container sy
 
 ## Getting logspout
 
-Logspout is a very small Docker container (14MB virtual, based on [Alpine](https://github.com/gliderlabs/docker-alpine)). Pull the latest release from the index:
+Logspout is a very small Docker container (15.2MB virtual, based on [Alpine](https://github.com/gliderlabs/docker-alpine)). Pull the latest release from the index:
 
 	$ docker pull gliderlabs/logspout:latest
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -e
-echo http://dl-4.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories
 apk add --update go git mercurial
 mkdir -p /go/src/github.com/gliderlabs
 cp -r /src /go/src/github.com/gliderlabs/logspout


### PR DESCRIPTION
Now using Alpine Linux 3.3 and GO 1.5.3.

I have removed the "edge" package repo for the "production" image build script. Even though "edge" offers us GO 1.6.0 (at the moment) I believe its best to use the same GO version in the "dev" and "production" images.

Images build with this patch:
```
logspout                  dev                 1dad5bc0db51        4 seconds ago       276.4 MB
logspout                  v3.1-dev            0a8f9c9009f7        18 minutes ago      15.2 MB
```

Output for dev image:
```
$ ROUTE=tcp://10.90.76.40:5555 make dev
# github.com/gliderlabs/logspout
link: warning: option -X main.Version dev may not work in future releases; use -X main.Version=dev
# logspout dev by gliderlabs
# adapters: udp tls raw syslog tcp
# options : debug:true persist:/mnt/routes
# jobs    : http[logs,routes]:80 pump
# routes  :
#   ADAPTER	ADDRESS		CONTAINERS	SOURCES	OPTIONS
#   raw+tcp	10.90.76.40:5555			map[]
2016/03/31 12:15:33 pump: 93bb4c2e3a0c started
2016/03/31 12:15:33 pump: 4d0f921c481e started
2016/03/31 12:15:33 pump: event: 85983efd5dff create
2016/03/31 12:15:33 pump: event: 85983efd5dff attach
2016/03/31 12:15:33 pump: event: 85983efd5dff start
2016/03/31 12:15:33 pump: 85983efd5dff started
2016/03/31 12:15:33 pump: event: 85983efd5dff die
2016/03/31 12:15:33 pump: event: 85983efd5dff destroy
^CMakefile:5: recipe for target 'dev' failed
```

Output for pro image:
```
$ docker run --rm -e DEBUG=true -v /var/runocker.sock:/var/run/docker.sock -e ROUTE_URIS=tcp://10.90.76.40:5555 logspout:v3.1-dev
# logspout v3.1-dev by gliderlabs
# adapters: raw syslog tcp udp tls
# options : debug:true persist:/mnt/routes
# jobs    : http[logs,routes]:80 pump
# routes  :
#   ADAPTER	ADDRESS		CONTAINERS	SOURCES	OPTIONS
#   raw+tcp	10.90.76.40:5555			map[]
2016/03/31 12:16:06 pump: e8b7778d4676 started
2016/03/31 12:16:06 pump: 4d0f921c481e started
2016/03/31 12:16:07 pump: event: 3f7e99e40d28 create
2016/03/31 12:16:07 pump: event: 3f7e99e40d28 attach
2016/03/31 12:16:07 pump: event: 3f7e99e40d28 start
2016/03/31 12:16:07 pump: 3f7e99e40d28 started
2016/03/31 12:16:07 pump: event: 3f7e99e40d28 die
2016/03/31 12:16:07 pump: event: 3f7e99e40d28 destroy
...
```

