### PR TITLE
More Flexible Dockerfile for Extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ EXPOSE 80
 COPY . /src
 RUN cd /src && ./build.sh "$(cat VERSION)"
 
-ONBUILD COPY ./modules.go /src/modules.go
+ONBUILD COPY . /src/
 ONBUILD RUN cd /src && ./build.sh "$(cat VERSION)-custom"


### PR DESCRIPTION
Updated Dockerfile to include the whole build space in the /src directory, making it more flexible to extend.

Since the ONBUILD directives are processed prior to any other directives in the child Dockerfile, I included the whole workspace in the src directory so you can inject other files into the /src directory prior to the build process.
