### PR TITLE
update container name if we get a rename event. closes #144

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,10 @@ ifneq ($(CIRCLE_BRANCH), release)
 	echo build-$$CIRCLE_BUILD_NUM > VERSION
 endif
 
-.PHONY: release
+clean:
+	rm -rf build/
+	docker rm $(shell docker ps -aq) || true
+	docker rmi $(NAME):dev $(NAME):$(VERSION) || true
+	docker rmi $(shell docker images -f 'dangling=true' -q) || true
+
+.PHONY: release clean


### PR DESCRIPTION
Uses new container name if we receive a `rename` event in the docker event stream

thanks to @josegonzalez for the code here
closes #144 
