### PR TITLE
Make Build Script Extentable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ EXPOSE 80
 COPY . /src
 RUN cd /src && ./build.sh "$(cat VERSION)"
 
+ONBUILD COPY ./build.sh /src/build.sh
 ONBUILD COPY ./modules.go /src/modules.go
 ONBUILD RUN cd /src && ./build.sh "$(cat VERSION)-custom"


### PR DESCRIPTION
since we use self signed certificates here, we have no option to install those certificates before the `build-sh` step. so we make it possible to provide an own `build.sh` script and run that instead of the vendored one...