### PR TITLE
ignore containers with unsupported log drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The simplest way to use logspout is to just take all logs and ship to a remote s
 		gliderlabs/logspout \
 		syslog://logs.papertrailapp.com:55555
 
-logspout will gather logs from other containers that are started **without the `-t` option**.
+logspout will gather logs from other containers that are started **without the `-t` option** and are configured with a logging driver that works with `docker logs` (`journald` and `json-file`).
 
 To see what data is used for syslog messages, see the [syslog adapter](http://github.com/gliderlabs/logspout/blob/master/adapters) docs.
 

--- a/router/pump.go
+++ b/router/pump.go
@@ -53,6 +53,15 @@ func normalID(id string) string {
 	return id
 }
 
+func logDriverSupported(container *docker.Container) bool {
+	switch container.HostConfig.LogConfig.Type {
+	case "json-file", "journald":
+		return true
+	default:
+		return false
+	}
+}
+
 func ignoreContainer(container *docker.Container) bool {
 	for _, kv := range container.Config.Env {
 		kvp := strings.SplitN(kv, "=", 2)
@@ -142,6 +151,10 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool) {
 	}
 	if ignoreContainer(container) {
 		debug("pump.pumpLogs():", id, "ignored: environ ignore")
+		return
+	}
+	if !logDriverSupported(container) {
+		debug("pump.pumpLogs():", id, "ignored: log driver not supported")
 		return
 	}
 


### PR DESCRIPTION
trying to hit /logs for a container that does not support that endpoint
results in the following error in that container's stdout

"Error running logs job: configured logging reader does not support
reading"

At least in our production environment (docker 1.9.1) the problem is amplified.  Logspout attempts to connect to the container's /log endpoint repeatedly resulting in a flood of such messages in the stdout of containers that are configured with the syslog driver.

This commit fixes that behavior and makes the supported log drivers explicit.