### PR TITLE
Use InactivityTimeout to work around a bug in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Routes are stored on disk, so by default routes are ephemeral. You can mount a v
 
 See [routesapi module](http://github.com/gliderlabs/logspout/blob/master/routesapi) for all options.
 
+#### Detecting timeouts in Docker log streams
+
+Logspout relies on the Docker API to retrieve container logs. A failure in the API may cause a log stream to hang. Logspout can detect and restart inactive Docker log streams. Use the environment variable `INACTIVITY_TIMEOUT` to enable this feature. E.g.: `INACTIVITY_TIMEOUT=1m` for a 1-minute threshold.
+
 ## Modules
 
 The standard distribution of logspout comes with all modules defined in this repository. You can remove or add new modules with custom builds of logspout. Just edit the `modules.go` file and do a `docker build`.

--- a/router/pump.go
+++ b/router/pump.go
@@ -78,7 +78,7 @@ func ignoreContainer(container *docker.Container) bool {
 
 func getInactivityTimeoutFromEnv() time.Duration {
 	inactivityTimeout, err := time.ParseDuration(getopt("INACTIVITY_TIMEOUT", "0"))
-        assert(err, "Couldn't parse env var INACTIVITY_TIMEOUT. See https://golang.org/pkg/time/#ParseDuration for valid format.")
+	assert(err, "Couldn't parse env var INACTIVITY_TIMEOUT. See https://golang.org/pkg/time/#ParseDuration for valid format.")
 	return inactivityTimeout
 }
 
@@ -189,14 +189,14 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 		for {
 			debug("pump.pumpLogs():", id, "started")
 			err := p.client.Logs(docker.LogsOptions{
-				Container:    id,
-				OutputStream: outwr,
-				ErrorStream:  errwr,
-				Stdout:       true,
-				Stderr:       true,
-				Follow:       true,
-				Tail:         "all",
-				Since:        sinceTime.Unix(),
+				Container:         id,
+				OutputStream:      outwr,
+				ErrorStream:       errwr,
+				Stdout:            true,
+				Stderr:            true,
+				Follow:            true,
+				Tail:              "all",
+				Since:             sinceTime.Unix(),
 				InactivityTimeout: inactivityTimeout,
 			})
 			if err != nil {
@@ -207,7 +207,7 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 
 			sinceTime = time.Now()
 			if err == docker.ErrInactivityTimeout {
-				sinceTime = sinceTime.Add(- inactivityTimeout)
+				sinceTime = sinceTime.Add(-inactivityTimeout)
 			}
 
 			container, err := p.client.InspectContainer(id)


### PR DESCRIPTION
Log rotation causes 'docker logs --follow' to stop outputting logs (docker/docker#23913).

We work around this by detecting inactivity in a log stream and restarting its pump. We restart the pump with argument Since=Now-InactivityTimeout to catch any logs we may have "missed" due to log rotation (this is harmless for truly silent log streams). We may still lose some logs from an app that's logging a lot due to small delays in recognizing an inactive stream on the Docker side and restarting a pump on the Logspout side.