### PR TITLE
Add custom CA and client certificates basic support for tls transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ You can tell logspout to use your custom client certificate by simply mounting y
 		gliderlabs/logspout \
 		tls://logs.my.server.com
 
-Logspout will automatically load certificates with file extensions crt and cert, keys with .key extension.
+Logspout will automatically load certificates with .crt/.cert file extensions and matching keys with .key extension.
 
 Example: user.cert, user.key
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,52 @@ See [routesapi module](http://github.com/gliderlabs/logspout/blob/master/routesa
 
 Logspout relies on the Docker API to retrieve container logs. A failure in the API may cause a log stream to hang. Logspout can detect and restart inactive Docker log streams. Use the environment variable `INACTIVITY_TIMEOUT` to enable this feature. E.g.: `INACTIVITY_TIMEOUT=1m` for a 1-minute threshold.
 
+#### Custom CA for TLS transport
+
+You can tell logspout to use your custom CA certificate by simply mounting your directory with certificates to /mnt/ca/:
+
+	$ docker run -d \
+		--name logspout \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v /path/to/ca/dir/:/mnt/ca/ \
+		gliderlabs/logspout \
+		tls://logs.my.server.com
+
+You can set custom CA certificate directory by adding CA_PATH env:
+
+	$ docker run -d \
+		--name logspout \
+		-e "CA_PATH=/data/ca/" \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v /path/to/ca/dir/:/data/ca/ \
+		gliderlabs/logspout \
+		tls://logs.my.server.com
+
+#### Custom client certificates for TLS transport
+
+You can tell logspout to use your custom client certificate by simply mounting your directory with certificate and key to /mnt/cert/:
+
+	$ docker run -d \
+		--name logspout \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v /path/to/cert/dir/:/mnt/cert/ \
+		gliderlabs/logspout \
+		tls://logs.my.server.com
+
+Logspout will automatically load certificates with file extensions crt and cert, keys with .key extension.
+
+Example: user.cert, user.key
+
+You can set custom client certificate directory by adding CERT_PATH env:
+
+	$ docker run -d \
+		--name logspout \
+		-e "CERT_PATH=/data/cert/" \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v /path/to/cert/dir/:/data/cert/ \
+		gliderlabs/logspout \
+		tls://logs.my.server.com
+
 #### Environment variables
 
 * `ALLOW_TTY` - include logs from containers started with `-t` or `--tty` (i.e. `Allocate a pseudo-TTY`)

--- a/transports/tls/tls.go
+++ b/transports/tls/tls.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
+	"log"
 	"net"
 	"os"
 	"strings"
@@ -48,11 +49,14 @@ func getCAs(path string) *x509.CertPool {
 		if !f.IsDir() {
 			cacert, err := ioutil.ReadFile(path + f.Name())
 			if err != nil {
-				// TODO: need to log something somewhere
+				log.Printf("Can't read CA certificate %v: %v", path+f.Name(), err)
 				continue
 			}
-			empty = false
-			capool.AppendCertsFromPEM(cacert)
+			ok := capool.AppendCertsFromPEM(cacert)
+			if !ok {
+				log.Printf("Bad CA certificate %v", path+f.Name())
+			}
+			empty = !ok && empty
 		}
 	}
 

--- a/transports/tls/tls.go
+++ b/transports/tls/tls.go
@@ -13,9 +13,10 @@ import (
 	"github.com/gliderlabs/logspout/router"
 )
 
+// default CA and certificate path
 const (
-	CA_PATH   = "/mnt/ca/"
-	CERT_PATH = "/mnt/cert/"
+	CAPath   = "/mnt/ca/"
+	CertPath = "/mnt/cert/"
 )
 
 func init() {
@@ -107,8 +108,8 @@ type tlsTransport int
 
 func (t *tlsTransport) Dial(addr string, options map[string]string) (net.Conn, error) {
 
-	capath := getopt("CA_PATH", CA_PATH)
-	certpath := getopt("CERT_PATH", CERT_PATH)
+	capath := getopt("CA_PATH", CAPath)
+	certpath := getopt("CERT_PATH", CertPath)
 
 	capool := getCAs(capath)
 

--- a/transports/tls/tls.go
+++ b/transports/tls/tls.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net"
 	"os"
-	"strings"
+	"path/filepath"
 
 	"github.com/gliderlabs/logspout/adapters/raw"
 	"github.com/gliderlabs/logspout/router"
@@ -76,15 +76,12 @@ func getCertificates(path string) []tls.Certificate {
 	}
 	for _, f := range certfiles {
 		fname := f.Name()
-		fext := ""
-		dotindex := strings.LastIndex(fname, ".")
-		if dotindex < 0 {
-			continue
-		}
-		fext = fname[dotindex+1 : len(fname)]
-		fname = fname[0:dotindex]
 
-		if fext != "crt" && fext != "cert" {
+		fext := filepath.Ext(fname)
+
+		fname = fname[0 : len(fname)-len(fext)]
+
+		if fext != ".crt" && fext != ".cert" {
 			continue
 		}
 
@@ -93,9 +90,9 @@ func getCertificates(path string) []tls.Certificate {
 			continue
 		}
 
-		cert, err := tls.LoadX509KeyPair(path+fname+"."+fext, keyfile)
+		cert, err := tls.LoadX509KeyPair(path+fname+fext, keyfile)
 		if err != nil {
-			return certs
+			continue
 		}
 
 		certs = append(certs, cert)

--- a/transports/tls/tls.go
+++ b/transports/tls/tls.go
@@ -1,19 +1,19 @@
 package tls
 
 import (
-	"os"
-	"net"
-	"strings"
-	"io/ioutil"
 	"crypto/tls"
 	"crypto/x509"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
 
 	"github.com/gliderlabs/logspout/adapters/raw"
 	"github.com/gliderlabs/logspout/router"
 )
 
 const (
-	CA_PATH = "/mnt/ca/"
+	CA_PATH   = "/mnt/ca/"
 	CERT_PATH = "/mnt/cert/"
 )
 
@@ -59,7 +59,7 @@ func getCAs(path string) *x509.CertPool {
 	if empty {
 		capool = nil
 	}
-	
+
 	return capool
 }
 
@@ -76,19 +76,19 @@ func getCertificates(path string) []tls.Certificate {
 		if dotindex < 0 {
 			continue
 		}
-		fext = fname[dotindex+1:len(fname)]
+		fext = fname[dotindex+1 : len(fname)]
 		fname = fname[0:dotindex]
 
 		if fext != "crt" && fext != "cert" {
 			continue
 		}
-		
+
 		keyfile := path + fname + ".key"
 		if _, err := os.Stat(keyfile); err != nil {
 			continue
 		}
 
-		cert, err := tls.LoadX509KeyPair(path + fname + "." + fext, keyfile)
+		cert, err := tls.LoadX509KeyPair(path+fname+"."+fext, keyfile)
 		if err != nil {
 			return certs
 		}
@@ -112,7 +112,7 @@ func (t *tlsTransport) Dial(addr string, options map[string]string) (net.Conn, e
 
 	config := tls.Config{Certificates: certs, RootCAs: capool}
 
-	conn, err := tls.Dial("tcp",  addr, &config)
+	conn, err := tls.Dial("tcp", addr, &config)
 
 	if err != nil {
 		return nil, err

--- a/transports/tls/tls.go
+++ b/transports/tls/tls.go
@@ -1,11 +1,20 @@
 package tls
 
 import (
-	"crypto/tls"
+	"os"
 	"net"
+	"strings"
+	"io/ioutil"
+	"crypto/tls"
+	"crypto/x509"
 
 	"github.com/gliderlabs/logspout/adapters/raw"
 	"github.com/gliderlabs/logspout/router"
+)
+
+const (
+	CA_PATH = "/mnt/ca/"
+	CERT_PATH = "/mnt/cert/"
 )
 
 func init() {
@@ -14,15 +23,97 @@ func init() {
 	router.AdapterFactories.Register(rawTLSAdapter, "tls")
 }
 
+func getopt(name, dfault string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		value = dfault
+	}
+	return value
+}
+
 func rawTLSAdapter(route *router.Route) (router.LogAdapter, error) {
 	route.Adapter = "raw+tls"
 	return raw.NewRawAdapter(route)
 }
 
+func getCAs(path string) *x509.CertPool {
+	cafiles, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil
+	}
+	capool := x509.NewCertPool()
+	// TODO: don't khow how to check pool is empty
+	empty := true
+	for _, f := range cafiles {
+		if !f.IsDir() {
+			cacert, err := ioutil.ReadFile(path + f.Name())
+			if err != nil {
+				// TODO: need to log something somewhere
+				continue
+			}
+			empty = false
+			capool.AppendCertsFromPEM(cacert)
+		}
+	}
+
+	if empty {
+		capool = nil
+	}
+	
+	return capool
+}
+
+func getCertificates(path string) []tls.Certificate {
+	certs := make([]tls.Certificate, 0)
+	certfiles, err := ioutil.ReadDir(path)
+	if err != nil {
+		return certs
+	}
+	for _, f := range certfiles {
+		fname := f.Name()
+		fext := ""
+		dotindex := strings.LastIndex(fname, ".")
+		if dotindex < 0 {
+			continue
+		}
+		fext = fname[dotindex+1:len(fname)]
+		fname = fname[0:dotindex]
+
+		if fext != "crt" && fext != "cert" {
+			continue
+		}
+		
+		keyfile := path + fname + ".key"
+		if _, err := os.Stat(keyfile); err != nil {
+			continue
+		}
+
+		cert, err := tls.LoadX509KeyPair(path + fname + "." + fext, keyfile)
+		if err != nil {
+			return certs
+		}
+
+		certs = append(certs, cert)
+	}
+
+	return certs
+}
+
 type tlsTransport int
 
 func (t *tlsTransport) Dial(addr string, options map[string]string) (net.Conn, error) {
-	conn, err := tls.Dial("tcp", addr, nil)
+
+	capath := getopt("CA_PATH", CA_PATH)
+	certpath := getopt("CERT_PATH", CERT_PATH)
+
+	capool := getCAs(capath)
+
+	certs := getCertificates(certpath)
+
+	config := tls.Config{Certificates: certs, RootCAs: capool}
+
+	conn, err := tls.Dial("tcp",  addr, &config)
+
 	if err != nil {
 		return nil, err
 	}

--- a/transports/tls/tls.go
+++ b/transports/tls/tls.go
@@ -69,7 +69,7 @@ func getCAs(path string) *x509.CertPool {
 }
 
 func getCertificates(path string) []tls.Certificate {
-	certs := make([]tls.Certificate, 0)
+	var certs []tls.Certificate
 	certfiles, err := ioutil.ReadDir(path)
 	if err != nil {
 		return certs


### PR DESCRIPTION
Add custom ca basic tls transport support:
- default ca path: /mnt/ca/;
- ca path can be set via CA_PATH env;

Add basic client certificates tls transport support:
- default certificates/keys path: /mnt/cert/;
- certificates/keys path can be set via CERT_PATH env;
- certificate names: .crt, .cert; key names: .key;
- example: user.cert, user.key
