### PR TITLE
Updating Dockerfile base image to gliderlabs/alpine:3.4 from 3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.4
 ENTRYPOINT ["/bin/logspout"]
 VOLUME /mnt/routes
 EXPOSE 80

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ cp -r /src /go/src/github.com/gliderlabs/logspout
 cd /go/src/github.com/gliderlabs/logspout
 export GOPATH=/go
 go get
-go build -ldflags "-X main.Version $1" -o /bin/logspout
+go build -ldflags "-X main.Version=$1" -o /bin/logspout
 apk del go git mercurial build-base
 rm -rf /go
 rm -rf /var/cache/apk/*

--- a/custom/build.sh
+++ b/custom/build.sh
@@ -6,7 +6,7 @@ cp -r /src /go/src/github.com/gliderlabs/logspout
 cd /go/src/github.com/gliderlabs/logspout
 export GOPATH=/go
 go get
-go build -ldflags "-X main.Version $1" -o /bin/logspout
+go build -ldflags "-X main.Version=$1" -o /bin/logspout
 apk del go git mercurial build-base
 rm -rf /go
 rm -rf /var/cache/apk/*


### PR DESCRIPTION
This was done to upgrade the go version and resolve a go build import
error for go-check

Fix for logspout issue #241 