### PR TITLE
Disable backlog on container start/restart.

### DIFF
--- a/router/pump.go
+++ b/router/pump.go
@@ -140,7 +140,7 @@ func (p *LogsPump) Run() error {
 		debug("pump.Run() event:", normalID(event.ID), event.Status)
 		switch event.Status {
 		case "start", "restart":
-			go p.pumpLogs(event, true, inactivityTimeout)
+			go p.pumpLogs(event, false, inactivityTimeout)
 		case "rename":
 			go p.rename(event)
 		case "die":


### PR DESCRIPTION
Addresses https://github.com/gliderlabs/logspout/issues/187, https://github.com/gliderlabs/logspout/issues/234

Sending the backlog does not really make sense on container restart or stop/start. Usually, you have those logs already and do not need duplicate ones.