### PR TITLE
syslog: Add support for SYSLOG_TIMESTAMP

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -49,6 +49,7 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 		structuredData = route.Options["structured_data"]
 	}
 	data := getopt("SYSLOG_DATA", "{{.Data}}")
+	timestamp := getopt("SYSLOG_TIMESTAMP", "{{.Timestamp}}")
 
 	if structuredData == "" {
 		structuredData = "-"
@@ -59,11 +60,11 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 	var tmplStr string
 	switch format {
 	case "rfc5424":
-		tmplStr = fmt.Sprintf("<%s>1 {{.Timestamp}} %s %s %s - %s %s\n",
-			priority, hostname, tag, pid, structuredData, data)
+		tmplStr = fmt.Sprintf("<%s>1 %s %s %s %s - %s %s\n",
+			priority, timestamp, hostname, tag, pid, structuredData, data)
 	case "rfc3164":
-		tmplStr = fmt.Sprintf("<%s>{{.Timestamp}} %s %s[%s]: %s\n",
-			priority, hostname, tag, pid, data)
+		tmplStr = fmt.Sprintf("<%s>%s %s %s[%s]: %s\n",
+			priority, timestamp, hostname, tag, pid, data)
 	default:
 		return nil, errors.New("unsupported syslog format: " + format)
 	}


### PR DESCRIPTION
Logspout is currently hardcoded to use RFC3339 timestamps. This can cause problems when using `SYSLOG_FORMAT=rfc3164` because some old-fashioned syslog servers insist on "Mmm dd hh:mm:ss" format.

Make logspout more flexible by adding support for a `SYSLOG_TIMESTAMP` environment variable containing a Go template. This template will be applied to a `SyslogMessage` value and defaults to `{{.Timestamp}}`, so there is no change to the current behavior.

Legacy "Mmm dd hh:mm:ss" timestamps can now be specified with:

    SYSLOG_TIMESTAMP='{{.Time.Format "Jan 02 15:04:05"}}'

Or RFC3339 timestamps with nanosecond precision can be specified with:

    SYSLOG_TIMESTAMP='{{.Time.Format "2006-01-02T15:04:05.999999999Z07:00"}}'