### PR TITLE
Context error

### DIFF
--- a/custom/build.sh
+++ b/custom/build.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
-apk add --update go git mercurial build-base ca-certificates
+echo "http://alpine.gliderlabs.com/alpine/v3.5/community" \
+    >> /etc/apk/repositories
+apk add --update 'go>1.7' git mercurial build-base ca-certificates
 mkdir -p /go/src/github.com/gliderlabs
 cp -r /src /go/src/github.com/gliderlabs/logspout
 cd /go/src/github.com/gliderlabs/logspout

--- a/custom/build.sh
+++ b/custom/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -ex
 echo "http://alpine.gliderlabs.com/alpine/v3.5/community" \
     >> /etc/apk/repositories
 apk add --update 'go>1.7' git mercurial build-base ca-certificates


### PR DESCRIPTION
I was running into this error when attempting to use the [logspout-logstash](https://github.com/looplab/logspout-logstash) plugin:

```
+ go get
package context: unrecognized import path "context" (import path does not begin with hostname)
ERROR: Service 'elk_logspout' failed to build: The command '/bin/sh -c cd /src && ./build.sh "$(cat VERSION)-custom"' returned a non-zero code: 1
```

After searching for a solution, I found that the package used to be named `net/context` in Go 1.6 and simply `context` in Go 1.7.

I'm unsure if I made the most ideal changes, but I've included my personal workaround until there's an official fix.

Thanks for the awesome software!