### PR TITLE
Add Rancher stack and service to structured data

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -44,7 +44,7 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 	hostname := getopt("SYSLOG_HOSTNAME", "{{.Container.Config.Hostname}}")
 	pid := getopt("SYSLOG_PID", "{{.Container.State.Pid}}")
 	tag := getopt("SYSLOG_TAG", "{{.ContainerName}}"+route.Options["append_tag"])
-	structuredData := getopt("SYSLOG_STRUCTURED_DATA", "")
+	structuredData := getopt("SYSLOG_STRUCTURED_DATA", "{{.StructuredData}}")
 	if route.Options["structured_data"] != "" {
 		structuredData = route.Options["structured_data"]
 	}
@@ -216,4 +216,8 @@ func (m *SyslogMessage) Timestamp() string {
 
 func (m *SyslogMessage) ContainerName() string {
 	return m.Message.Container.Name[1:]
+}
+
+func (m *SyslogMessage) StructuredData() string {
+	return fmt.Sprintf("uphold@1 stack=\"%s\" service=\"%s\"", m.Message.Stack, m.Message.Service)
 }

--- a/router/pump.go
+++ b/router/pump.go
@@ -139,8 +139,10 @@ func (p *LogsPump) Run() error {
 	for event := range events {
 		debug("pump.Run() event:", normalID(event.ID), event.Status)
 		switch event.Status {
-		case "start", "restart":
+		case "start":
 			go p.pumpLogs(event, true, inactivityTimeout)
+		case "restart":
+			go p.pumpLogs(event, false, inactivityTimeout)
 		case "rename":
 			go p.rename(event)
 		case "die":
@@ -307,6 +309,17 @@ type containerPump struct {
 }
 
 func newContainerPump(container *docker.Container, stdout, stderr io.Reader) *containerPump {
+	stack := ""
+	service := ""
+
+	if container.Config.Labels != nil {
+		if stackService, ok := container.Config.Labels ["io.rancher.stack_service.name"]; ok {
+			splitStackService := strings.Split(stackService, "/")
+			stack = splitStackService[0]
+			service = splitStackService[1]
+		}
+	}
+
 	cp := &containerPump{
 		container:  container,
 		logstreams: make(map[chan *Message]*Route),
@@ -326,6 +339,8 @@ func newContainerPump(container *docker.Container, stdout, stderr io.Reader) *co
 				Container: container,
 				Time:      time.Now(),
 				Source:    source,
+				Service:   service,
+				Stack:	   stack,
 			})
 		}
 	}

--- a/router/types.go
+++ b/router/types.go
@@ -50,8 +50,10 @@ type RouteStore interface {
 // Messages are log messages
 type Message struct {
 	Container *docker.Container
-	Source    string
 	Data      string
+	Service   string
+	Source    string
+	Stack	  string
 	Time      time.Time
 }
 


### PR DESCRIPTION
Implements [Add stack and service to logspout](https://jira.uphold.com/browse/INFRA-1167).

Also includes change that does not pump full log on a restart.