### PR TITLE
Allow containers with TTY enabled using environment variable ALLOW_TTY=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Logspout relies on the Docker API to retrieve container logs. A failure in the A
 
 #### Environment variables
 
+* `ALLOW_TTY` - include logs from containers started with `-t` or `--tty` (i.e. `Allocate a pseudo-TTY`)
 * `DEBUG` - emit debug logs
 * `EXCLUDE_LABEL` - exclude logs with a given label
 * `INACTIVITY_TIMEOUT` - detect hang in Docker API (default 0)

--- a/router/pump.go
+++ b/router/pump.go
@@ -159,8 +159,10 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 	container, err := p.client.InspectContainer(id)
 	assert(err, "pump")
 	if container.Config.Tty {
-		debug("pump.pumpLogs():", id, "ignored: tty enabled")
-		return
+		if allowTty := getopt("ALLOW_TTY", ""); allowTty != "true" {
+			debug("pump.pumpLogs():", id, "ignored: tty enabled")
+			return
+		}
 	}
 	if ignoreContainer(container) {
 		debug("pump.pumpLogs():", id, "ignored: environ ignore")


### PR DESCRIPTION
pulled this in from @davidnortonjr thanks!

closes #231