### PR TITLE
use glide in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,14 @@ EXPOSE 80
 
 ENV GOPATH=/go
 ENV LSPATH=/go/src/github.com/gliderlabs/logspout
-RUN mkdir -p $LSPATH
+RUN apk update && apk add --update git
 
+RUN mkdir -p $LSPATH
 ADD . $LSPATH
+RUN cd $LSPATH && go get github.com/Masterminds/glide && $GOPATH/bin/glide install
 RUN cd $LSPATH && go build -o /bin/logspout
+RUN apk del git pcre expat libcurl libssh2
+RUN rm -rf $GOPATH/bin/glide $GOPATH/src/github.com/Masterminds/glide /root/.glide /tmp/* /root/* /var/cache/apk/*
 
 ONBUILD COPY ./modules.go ${LSPATH}/modules.go
 ONBUILD RUN cd $LSPATH && go get

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: build
+
 NAME=logspout
 VERSION=$(shell cat VERSION)
 ifeq ($(shell uname), Darwin)

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,6 @@ machine:
 dependencies:
   pre:
     - go get github.com/golang/lint/golint
-    - docker run --rm -it -v $PWD:/go/src/github.com/gliderlabs/logspout -w /go/src/github.com/gliderlabs/logspout treeder/glide install
     - make circleci
   override:
     - make build


### PR DESCRIPTION
When we merged the build refactor using glide, it broke the hub build since we were only calling `glide` on CI. This calls `glide` from the `Dockerfile`.

closes #284