### PR TITLE
Consider ECONNRESET a non-temporary error.

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -139,7 +140,7 @@ func (a *Adapter) Stream(logstream chan *router.Message) {
 
 func (a *Adapter) retry(buf []byte, err error) error {
 	if opError, ok := err.(*net.OpError); ok {
-		if opError.Temporary() || opError.Timeout() {
+		if (opError.Temporary() && opError.Err != syscall.ECONNRESET) || opError.Timeout() {
 			retryErr := a.retryTemporary(buf)
 			if retryErr == nil {
 				return nil


### PR DESCRIPTION
This PR ensures that the `syslog` adapter treats ECONNRESET errors as "non-temporary", meaning that we immediately recreate the connection instead of first attempting to re-send the failed packets on the existing connection.

It should be noted, there are cases ("under certain rapid connection setup/teardown conditions") where ECONNRESET *can* be a temporary error. See the [Golang issue](https://github.com/golang/go/issues/6163) and associated [commit](https://github.com/golang/go/commit/a07a57b00ec9fdd8f6b02360d39454859709d08a). 

However, it seems to me that of the real-world cases where an ECONNRESET is encountered, the great majority of the problems would be non-temporary. For example, Papertrail delivers an ECONNRESET after 15 minutes of inactivity, which indicates that they have permanently closed the connection and we need to open a new one.