### PR TITLE
router/pump: remove logstream send timeout

### DIFF
--- a/router/pump.go
+++ b/router/pump.go
@@ -371,15 +371,7 @@ func (cp *containerPump) send(msg *Message) {
 		if !route.MatchMessage(msg) {
 			continue
 		}
-		select {
-		case logstream <- msg:
-		case <-time.After(time.Second * 1):
-			debug("pump.send(): send timeout, closing")
-			// normal call to remove() triggered by
-			// route.Closer() may not be able to grab
-			// lock under heavy load, so we delete here
-			defer delete(cp.logstreams, logstream)
-		}
+		logstream <- msg
 	}
 }
 

--- a/router/pump_test.go
+++ b/router/pump_test.go
@@ -175,19 +175,6 @@ func TestPumpContainerPump(t *testing.T) {
 	}
 }
 
-func TestPumpSendTimeout(t *testing.T) {
-	container := &docker.Container{
-		ID: "8dfafdbc3a40",
-	}
-	pump := newContainerPump(container, os.Stdout, os.Stderr)
-	ch, route := make(chan *Message), &Route{}
-	pump.add(ch, route)
-	pump.send(&Message{Data: "hellooo"})
-	if pump.logstreams[ch] != nil {
-		t.Error("expected logstream to be removed after timeout")
-	}
-}
-
 func TestPumpRoutingFrom(t *testing.T) {
 	container := &docker.Container{
 		ID: "8dfafdbc3a40",


### PR DESCRIPTION
Previously a containers logstream would be closed after a send on
its logstream channel was blocked for 1 second, causing it to not
forward logs until logspout received a start event for the container.

A send to a logstream could happen due to a closed syslog/tcp connection
or any delay in an adapters Stream from processing incoming messages.

Although this commit fixes the current issue, it does open up the
possibility for a send on a logstream to block for an indefinite amount
of time.