### PR TITLE
Close existing routes when adding a new route with an existing ID.

### DIFF
--- a/router/pump.go
+++ b/router/pump.go
@@ -303,6 +303,7 @@ func (p *LogsPump) Route(route *Route, logstream chan *Message) {
 		p.mu.Lock()
 		delete(p.routes, updates)
 		p.mu.Unlock()
+		route.closed = true
 	}()
 	for {
 		select {

--- a/router/routes.go
+++ b/router/routes.go
@@ -136,6 +136,11 @@ func (rm *RouteManager) Add(route *Route) error {
 	}
 	route.closer = make(chan bool)
 	route.adapter = adapter
+	//Stop any existing route with this ID:
+	if( rm.routes[route.ID] != nil ){
+		rm.routes[route.ID].closer <- true
+	}
+
 	rm.routes[route.ID] = route
 	if rm.persistor != nil {
 		if err := rm.persistor.Add(route); err != nil {

--- a/router/routes.go
+++ b/router/routes.go
@@ -137,7 +137,7 @@ func (rm *RouteManager) Add(route *Route) error {
 	route.closer = make(chan bool)
 	route.adapter = adapter
 	//Stop any existing route with this ID:
-	if( rm.routes[route.ID] != nil ){
+	if rm.routes[route.ID] != nil {
 		rm.routes[route.ID].closer <- true
 	}
 

--- a/router/routes_test.go
+++ b/router/routes_test.go
@@ -5,6 +5,18 @@ import (
 	"testing"
 )
 
+type DummyAdapter struct{}
+
+func (a *DummyAdapter) Stream(logstream chan *Message) {
+	for message := range logstream {
+		print( "message passed to DummyAdapter: ", message )
+	}
+}
+
+func newDummyAdapter(route *Route) (LogAdapter, error) {
+	return &DummyAdapter{}, nil
+}
+
 func TestRouterGetAll(t *testing.T) {
 	rts, err := Routes.GetAll()
 	if err != nil {
@@ -14,5 +26,35 @@ func TestRouterGetAll(t *testing.T) {
 	emptyRoutes := append(marshal(make([]*Route, 0)), '\n')
 	if !reflect.DeepEqual(routes, emptyRoutes) {
 		t.Error("expected '[]' got:", routes)
+	}
+}
+
+func TestRouterNoDuplicateIds(t *testing.T) {
+	AdapterFactories.Register(newDummyAdapter, "syslog")
+
+	//Mock "running" so routes actually start running when added.
+	Routes.routing = true
+
+	//Start the first route.
+	route1 := &Route{
+		ID: "abc",
+		Address: "someUrl",
+		Adapter: "syslog",
+	}
+	err := Routes.Add(route1)
+	if err != nil {
+		t.Error("Error adding route:", err)
+	}
+
+	//Start a second route with the same ID.
+	var route2 = &Route{
+		ID: "abc",
+		Address: "someUrl2",
+		Adapter: "syslog",
+	}
+	Routes.Add(route2)
+
+	if( !route1.closed ){
+		t.Errorf("route1 was not closed after route2 added." )
 	}
 }

--- a/router/routes_test.go
+++ b/router/routes_test.go
@@ -9,7 +9,7 @@ type DummyAdapter struct{}
 
 func (a *DummyAdapter) Stream(logstream chan *Message) {
 	for message := range logstream {
-		print( "message passed to DummyAdapter: ", message )
+		print("message passed to DummyAdapter: ", message)
 	}
 }
 
@@ -37,24 +37,23 @@ func TestRouterNoDuplicateIds(t *testing.T) {
 
 	//Start the first route.
 	route1 := &Route{
-		ID: "abc",
+		ID:      "abc",
 		Address: "someUrl",
 		Adapter: "syslog",
 	}
-	err := Routes.Add(route1)
-	if err != nil {
+	if err := Routes.Add(route1); err != nil {
 		t.Error("Error adding route:", err)
 	}
 
 	//Start a second route with the same ID.
 	var route2 = &Route{
-		ID: "abc",
+		ID:      "abc",
 		Address: "someUrl2",
 		Adapter: "syslog",
 	}
 	Routes.Add(route2)
 
-	if( !route1.closed ){
-		t.Errorf("route1 was not closed after route2 added." )
+	if !route1.closed {
+		t.Errorf("route1 was not closed after route2 added.")
 	}
 }

--- a/router/types.go
+++ b/router/types.go
@@ -67,6 +67,7 @@ type Route struct {
 	Address       string            `json:"address"`
 	Options       map[string]string `json:"options,omitempty"`
 	adapter       LogAdapter
+	closed	      bool
 	closer        chan bool
 	closerRcv     <-chan bool // used instead of closer when set
 }


### PR DESCRIPTION
Fixes #305 .

I added a test, and then needed to add a closed flag to verify that closer was being called. If anyone has a better way to do this, that doesn't require the extra flag I'd be interested to see it!