### PR TITLE
Fix TTY support

### DIFF
--- a/router/pump.go
+++ b/router/pump.go
@@ -226,6 +226,7 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 				Tail:              "all",
 				Since:             sinceTime.Unix(),
 				InactivityTimeout: inactivityTimeout,
+				RawTerminal:  allowTTY
 			})
 			if err != nil {
 				debug("pump.pumpLogs():", id, "stopped with error:", err)

--- a/router/pump.go
+++ b/router/pump.go
@@ -226,7 +226,7 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 				Tail:              "all",
 				Since:             sinceTime.Unix(),
 				InactivityTimeout: inactivityTimeout,
-				RawTerminal:  allowTTY
+				RawTerminal:  allowTTY,
 			})
 			if err != nil {
 				debug("pump.pumpLogs():", id, "stopped with error:", err)


### PR DESCRIPTION
This PR should fix #310.

According to the code of docker client library used we should set RawTerminal option to true if we want to get logs from container with TTY flag see the comment from the lib itself :
"Use raw terminal? Usually true when the container contains a TTY."

Tested over few containers with and without the option it seems to be working like a charm.

Meanwhile if you want to test :
* adopteunops/logspout:latest 
* adopteunops/logspout-logstash:20170823 