### PR TITLE
Tail env

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can route to multiple destinations by comma-separating the URIs:
 		raw://192.168.10.10:5000?filter.name=*_db,syslog+tls://logs.papertrailapp.com:55555?filter.name=*_app
 
 #### Suppressing backlog tail
-You can tell logspout to only display log entries since container "start" or "restart" event by setting a `BACKLOG=false` environment variable (equivalent to `docker logs --tail=0`):
+You can tell logspout to only display log entries since container "start" or "restart" event by setting a `BACKLOG=false` environment variable (equivalent to `docker logs --since=0s`):
 
 	$ docker run -d --name="logspout" \
 		-e 'BACKLOG=false' \
@@ -98,6 +98,10 @@ You can tell logspout to only display log entries since container "start" or "re
 The default behaviour is to output all logs since creation of the container (equivalent to `docker logs --tail=all` or simply `docker logs`).
 
 > NOTE: Use of this option **may** cause the first few lines of log output to be missed following a container being started, if the container starts outputting logs before logspout has a chance to see them. If consistent capture of *every* line of logs is critical to your application, you might want to test thorougly and/or avoid this option (at the expense of getting the entire backlog for every restarting container). This does not affect containers that are removed and recreated.
+
+
+#### Environment variable, TAIL
+Whilst BACKLOG=false restricts the tail by setting the Docker Logs.Options.Since to time.Now(), another mechanism to restrict the tail is to set TAIL=n.  Use of this mechanism avoids parsing the earlier content of the logfile which may have a speed advantage if the tail content is of no interest or has become corrupted.
 
 #### Inspect log streams using curl
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Logspout relies on the Docker API to retrieve container logs. A failure in the A
 
 * `ALLOW_TTY` - include logs from containers started with `-t` or `--tty` (i.e. `Allocate a pseudo-TTY`)
 * `BACKLOG` - suppress container tail backlog
+* `TAIL` - specify the number of lines in the log tail to capture when logspout starts (default `all`)
 * `DEBUG` - emit debug logs
 * `EXCLUDE_LABEL` - exclude logs with a given label
 * `INACTIVITY_TIMEOUT` - detect hang in Docker API (default 0)

--- a/router/pump.go
+++ b/router/pump.go
@@ -195,6 +195,7 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 		return
 	}
 
+	var tail = getopt("TAIL", "all")
 	var sinceTime time.Time
 	if backlog {
 		sinceTime = time.Unix(0, 0)
@@ -215,7 +216,7 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 	p.update(event)
 	go func() {
 		for {
-			debug("pump.pumpLogs():", id, "started, tail:", getopt("TAIL", "all"))
+			debug("pump.pumpLogs():", id, "started, tail:", tail)
 			err := p.client.Logs(docker.LogsOptions{
 				Container:         id,
 				OutputStream:      outwr,
@@ -223,7 +224,7 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 				Stdout:            true,
 				Stderr:            true,
 				Follow:            true,
-				Tail:              getopt("TAIL", "all"),
+				Tail:              tail,
 				Since:             sinceTime.Unix(),
 				InactivityTimeout: inactivityTimeout,
 				RawTerminal:       allowTTY,

--- a/router/pump.go
+++ b/router/pump.go
@@ -215,7 +215,7 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 	p.update(event)
 	go func() {
 		for {
-			debug("pump.pumpLogs():", id, "started")
+			debug("pump.pumpLogs():", id, "started, tail:", getopt("TAIL", "all"))
 			err := p.client.Logs(docker.LogsOptions{
 				Container:         id,
 				OutputStream:      outwr,
@@ -223,10 +223,10 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 				Stdout:            true,
 				Stderr:            true,
 				Follow:            true,
-				Tail:              "all",
+				Tail:              getopt("TAIL", "all"),
 				Since:             sinceTime.Unix(),
 				InactivityTimeout: inactivityTimeout,
-				RawTerminal:  allowTTY,
+				RawTerminal:       allowTTY,
 			})
 			if err != nil {
 				debug("pump.pumpLogs():", id, "stopped with error:", err)


### PR DESCRIPTION
Add a new environment variable, "TAIL" to allow the docker logs --tail option to be configured.  At present, it is hardcoded to "all"

Setting TAIL=0 looks like a workaround for issue #246 since it avoids parsing of the earlier and potentially corrupt content of the JSON log file.  Note, at present, the BACKLOG=false option does not workaround this issue since the logfile is still parsed to determine the timestamps of the logs

Update the README with details of the TAIL envvar