### PR TITLE
toJSON function on raw

### DIFF
--- a/adapters/raw/raw.go
+++ b/adapters/raw/raw.go
@@ -21,7 +21,7 @@ var funcs = template.FuncMap{
 	"toJSON": func(value interface{}) string {
 		bytes, err := json.Marshal(value)
 		if err != nil {
-			log.Println("raw:", err)
+			log.Println("error marshalling to JSON: ", err)
 			return "null"
 		}
 		return string(bytes)

--- a/adapters/raw/raw.go
+++ b/adapters/raw/raw.go
@@ -22,10 +22,9 @@ var funcs = template.FuncMap{
 		bytes, err := json.Marshal(value)
 		if err != nil {
 			log.Println("raw:", err)
-			return "\"\""
+			return "null"
 		}
 		return string(bytes)
-
 	},
 }
 

--- a/adapters/raw/raw.go
+++ b/adapters/raw/raw.go
@@ -2,6 +2,7 @@ package raw
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"log"
 	"net"
@@ -14,6 +15,18 @@ import (
 
 func init() {
 	router.AdapterFactories.Register(NewRawAdapter, "raw")
+}
+
+var funcs = template.FuncMap{
+	"toJSON": func(value interface{}) string {
+		bytes, err := json.Marshal(value)
+		if err != nil {
+			log.Println("raw:", err)
+			return "\"\""
+		}
+		return string(bytes)
+
+	},
 }
 
 // NewRawAdapter returns a configured raw.Adapter
@@ -30,7 +43,7 @@ func NewRawAdapter(route *router.Route) (router.LogAdapter, error) {
 	if os.Getenv("RAW_FORMAT") != "" {
 		tmplStr = os.Getenv("RAW_FORMAT")
 	}
-	tmpl, err := template.New("raw").Parse(tmplStr)
+	tmpl, err := template.New("raw").Funcs(funcs).Parse(tmplStr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add support to convert `structs` and escape `strings` usings JSON formatting rules.

Then the Raw Adapter will the able to generate JSON-like output in a simple way, or full JSON output.

Use examples:

### Mixed JSON + generic:
```
{{ .Time.Format "2006-01-02T15:04:05Z07:00" }} { "container" : "{{ .Container.Name }}", "labels": {{ toJSON .Container.Config.Labels }}, "timestamp": "{{ .Time.Format "2006-01-02T15:04:05Z07:00" }}", "source" : "{{ .Source }}", "message": {{ toJSON .Data }} }
```

```
2017-10-26T11:59:32Z { "container" : "/catalogo_worker_1", "image": "sha256:e9bce6c17c80c603c4c8dbac2ad2285982d218f6ea0332f8b0fb84572941b773", "labels": {"com.docker.compose.config-hash":"4f9c3d3bfb2f65e29a4bc8a4a1b3f0a1c8a42323106a5e9106fe9279f8031321","com.docker.compose.container-number":"1","com.docker.compose.oneoff":"False","com.docker.compose.project":"catalogo","com.docker.compose.service":"worker","com.docker.compose.version":"1.16.1","logging":"true"}, "timestamp": "2017-10-26T11:59:32Z", "source" : "stdout", "message": "2017-10-26 11:59:32,950 INFO success: command_bus_0 entered RUNNING state, process has stayed up for \u003e than 1 seconds (startsecs)" }
```

### Full JSON like:
```
{ "container" : "{{ .Container.Name }}", "labels": {{ toJSON .Container.Config.Labels }}, "timestamp": "{{ .Time.Format "2006-01-02T15:04:05Z07:00" }}", "source" : "{{ .Source }}", "message": {{ toJSON .Data }} }
```

```json
{
  "container": "/a_container",
  "image": "sha256:e9bce6c17c80c603c4c8dbac2ad2285982d218f6ea0332f8b0fb84572941b773",
  "labels": {
    "com.docker.compose.config-hash": "4f9c3d3bfb2f65e29a4bc8a4a1b3f0a1c8a42323106a5e9106fe9279f8031321",
    "com.docker.compose.container-number": "1",
    "com.docker.compose.oneoff": "False",
    "com.docker.compose.project": "a_project",
    "com.docker.compose.service": "worker",
    "com.docker.compose.version": "1.16.1",
    "logging": "true"
  },
  "timestamp": "2017-10-26T11:59:32Z",
  "source": "stdout",
  "message": "2017-10-26 11:59:32,950 INFO success: command_bus_0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)"
}

```