### PR TITLE
revert dropping header,  for only setting RawTerminal when container tty

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 521f9762f9a2bb54ab827d2d6e8264d0b3e34321b3b785ea4e38b30fc0ca26c2
-updated: 2017-11-01T16:53:18.861075104-05:00
+hash: 83a577e65396190336bd5117580f29dbf983a3e2fdc5732a111ae56f229ed978
+updated: 2017-11-07T22:39:32.638917215-06:00
 imports:
 - name: github.com/docker/docker
   version: ad969f1aa782478725a7f338cf963fa82f484609
@@ -30,8 +30,6 @@ imports:
   version: 9fa818a44c2bf1396a17f9d5a3c0f6dd39d2ff8e
 - name: github.com/hashicorp/go-cleanhttp
   version: ad28ea4487f05916463e2423a55166280e8254b5
-- name: github.com/hashicorp/go-version
-  version: fc61389e27c71d120f87031ca8c88a3428f372dd
 - name: github.com/opencontainers/runc
   version: 9d7831e41d3ef428b67685eeb27f2b4a22a92391
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,4 +7,3 @@ import:
 - package: golang.org/x/net
   subpackages:
   - websocket
-- package: github.com/hashicorp/go-version

--- a/router/pump.go
+++ b/router/pump.go
@@ -212,7 +212,7 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 
 	// RawTerminal with contianer Tty=false injects binary headers into
 	// the log stream that show up as garbage unicode characters
-	var rawTerminal bool = false
+	rawTerminal := false 
 	if allowTTY && container.Config.Tty {
 		rawTerminal = true
 	}

--- a/router/pump.go
+++ b/router/pump.go
@@ -210,7 +210,7 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool, inactivityTim
 		return
 	}
 
-	// RawTerminal with contianer Tty=false injects binary headers into
+	// RawTerminal with container Tty=false injects binary headers into
 	// the log stream that show up as garbage unicode characters
 	rawTerminal := false 
 	if allowTTY && container.Config.Tty {

--- a/router/pump_test.go
+++ b/router/pump_test.go
@@ -135,10 +135,7 @@ func TestPumpContainerRename(t *testing.T) {
 		Name:   "foo",
 		Config: config,
 	}
-	version := &docker.Env{
-		"ApiVersion=1.33",
-	}
-	p.pumps["8dfafdbc3a40"] = newContainerPump(container, version, os.Stdout, os.Stderr)
+	p.pumps["8dfafdbc3a40"] = newContainerPump(container, os.Stdout, os.Stderr)
 	if name := p.pumps["8dfafdbc3a40"].container.Name; name != "foo" {
 		t.Errorf("containerPump should have name: 'foo' got name: '%s'", name)
 	}
@@ -156,10 +153,7 @@ func TestPumpNewContainerPump(t *testing.T) {
 		ID:     "8dfafdbc3a40",
 		Config: config,
 	}
-	version := &docker.Env{
-		"ApiVersion=1.33",
-	}
-	pump := newContainerPump(container, version, os.Stdout, os.Stderr)
+	pump := newContainerPump(container, os.Stdout, os.Stderr)
 	if pump == nil {
 		t.Error("pump nil")
 		return
@@ -174,10 +168,7 @@ func TestPumpContainerPump(t *testing.T) {
 		ID:     "8dfafdbc3a40",
 		Config: config,
 	}
-	version := &docker.Env{
-		"ApiVersion=1.33",
-	}
-	pump := newContainerPump(container, version, os.Stdout, os.Stderr)
+	pump := newContainerPump(container, os.Stdout, os.Stderr)
 	logstream, route := make(chan *Message), &Route{}
 	go func() {
 		for msg := range logstream {


### PR DESCRIPTION
This PR pretty much reverts the changes in PR #346 

After digging deeper into issue #331, it looks like actual issue is setting RawTerminal = allowTTY. 

Raw output is fine on containers that have Tty=true, but docker includes stream headers when container Tty=false. 

