### PR TITLE
chmod +x build.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN cd /src && ./build.sh "$(cat VERSION)"
 
 ONBUILD COPY ./build.sh /src/build.sh
 ONBUILD COPY ./modules.go /src/modules.go
-ONBUILD RUN cd /src && ./build.sh "$(cat VERSION)-custom"
+ONBUILD RUN cd /src && chmod +x ./build.sh && ./build.sh "$(cat VERSION)-custom"


### PR DESCRIPTION
Tested OK i Gitlab-CI for custom builds. Was not able to work around this without build.sh being executable in the upstream Dockerfile. 