### PR TITLE
panic if reconnect fails

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -143,7 +143,7 @@ func (a *Adapter) Stream(logstream chan *router.Message) {
 				continue
 			default:
 				if err = a.retry(buf, err); err != nil {
-					log.Println("syslog retry err:", err)
+					log.Panicf("syslog retry err: %+v", err)
 					return
 				}
 			}


### PR DESCRIPTION
Currently, when logspout fails to reconnect it will sit there not doing anything.  I would rather see it restart itself than miss hours important log data.  

Please let me know if this is the appropriate behavior or if you would rather it do something else.