### PR TITLE
Added handling for logs in JSON fromat in template

### DIFF
--- a/adapters/raw/raw.go
+++ b/adapters/raw/raw.go
@@ -34,8 +34,8 @@ var funcs = template.FuncMap{
 
 		bytes, err := json.Marshal(value)
 		if err != nil {
-			log.Println("error marshalling to JSON: ", err)
-			return fmt.Sprintf("logspout: error marshalling to JSON: %s", err)
+			log.Println("error marshaling to JSON: ", err)
+			return fmt.Sprintf("logspout: error marshaling to JSON: %s", err)
 		}
 		return string(bytes)
 	},

--- a/adapters/raw/raw.go
+++ b/adapters/raw/raw.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -19,10 +20,22 @@ func init() {
 
 var funcs = template.FuncMap{
 	"toJSON": func(value interface{}) string {
+		// Check if input is valid JSON already
+		switch v := value.(type) {
+		case string:
+			if json.Valid([]byte(v)) {
+				return v
+			}
+		case []byte:
+			if json.Valid(v) {
+				return string(v)
+			}
+		}
+
 		bytes, err := json.Marshal(value)
 		if err != nil {
 			log.Println("error marshalling to JSON: ", err)
-			return "null"
+			return fmt.Sprintf("logspout: error marshalling to JSON: %s", err)
 		}
 		return string(bytes)
 	},

--- a/adapters/raw/raw_test.go
+++ b/adapters/raw/raw_test.go
@@ -1,0 +1,34 @@
+package raw
+
+import (
+	"testing"
+)
+
+func Test_toJSON(t *testing.T) {
+
+	toJSON := funcs["toJSON"].(func(interface{}) string)
+
+	type args struct {
+		value interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"json_string", args{`{"my":"json"}`}, `{"my":"json"}`},
+		{"json_string1", args{`{"my":"json", "dry":"ice"}`}, `{"my":"json", "dry":"ice"}`},
+		{"nonjson_string1", args{`{"my":json"}`}, `"{\"my\":json\"}"`},
+		{"nonjson_string2", args{`Alice and Bob`}, `"Alice and Bob"`},
+		{"other", args{struct{ Name string }{"Megan"}}, `{"Name":"Megan"}`},
+		{"json_byte", args{[]byte(`{"my":"json"}`)}, `{"my":"json"}`},
+		{"json_byte1", args{[]byte(`{"my":"json", "dry":"ice"}`)}, `{"my":"json", "dry":"ice"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toJSON(tt.args.value); got != tt.want {
+				t.Errorf("toJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Strings or bytes formatted as proper JSON would not be marshaled another time. I added also informative error instead of "null" so any errors could be discovered and fixed.