### PR TITLE
Update 3rd party module link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The standard distribution of logspout comes with all modules defined in this rep
 
 ### Third-party modules
 
- * [logspout-kafka](https://github.com/gettyimages/logspout-kafka)
+ * [logspout-kafka](https://github.com/dylanmei/logspout-kafka)
  * logspout-redis...
  * [logspout-logstash](https://github.com/looplab/logspout-logstash)
  * [logspout-redis-logstash](https://github.com/rtoma/logspout-redis-logstash)


### PR DESCRIPTION
The ownership of `gettyimages/logspout-kafka` was transferred to `dylanmei/logspout-kafka`. The link in the README is updated.