### PR TITLE
Add bind address option for routesapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - @gbolo added option to load TLS client certificate and key
 - @gbolo added ability to control the TLS client trust store
 - @gbolo added option to harden the TLS client
+- @chopmann added option to bind the http server to an address
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ If you use multiline logging with raw, it's recommended to json encode the Data 
 * `DEBUG` - emit debug logs
 * `EXCLUDE_LABEL` - exclude logs with a given label
 * `INACTIVITY_TIMEOUT` - detect hang in Docker API (default 0)
+* `HTTP_BIND_ADDRESS` - configure which address to listen on (default 0.0.0.0)
 * `PORT` or `HTTP_PORT` - configure which port to listen on (default 80)
 * `RAW_FORMAT` - log format for the raw adapter (default `{{.Data}}\n`)
 * `RETRY_COUNT` - how many times to retry a broken socket (default 10)

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If you use multiline logging with raw, it's recommended to json encode the Data 
 * `DEBUG` - emit debug logs
 * `EXCLUDE_LABEL` - exclude logs with a given label
 * `INACTIVITY_TIMEOUT` - detect hang in Docker API (default 0)
-* `HTTP_BIND_ADDRESS` - configure which address to listen on (default 0.0.0.0)
+* `HTTP_BIND_ADDRESS` - configure which interface address to listen on (default 0.0.0.0)
 * `PORT` or `HTTP_PORT` - configure which port to listen on (default 80)
 * `RAW_FORMAT` - log format for the raw adapter (default `{{.Data}}\n`)
 * `RETRY_COUNT` - how many times to retry a broken socket (default 10)

--- a/router/http.go
+++ b/router/http.go
@@ -7,12 +7,14 @@ import (
 )
 
 func init() {
+	bindAddress := getopt("HTTP_BIND_ADDRESS", "0.0.0.0")
 	port := getopt("PORT", getopt("HTTP_PORT", "80"))
-	Jobs.Register(&httpService{port}, "http")
+	Jobs.Register(&httpService{bindAddress, port}, "http")
 }
 
 type httpService struct {
-	port string
+	bindAddress string
+	port        string
 }
 
 func (s *httpService) Name() string {
@@ -30,5 +32,5 @@ func (s *httpService) Setup() error {
 }
 
 func (s *httpService) Run() error {
-	return http.ListenAndServe(":"+s.port, nil)
+	return http.ListenAndServe(s.bindAddress+":"+s.port, nil)
 }


### PR DESCRIPTION
Did not see a reason why not to bind the HTTP Server to an specific Address. I assume most deployments just run the container with one interface, but if not or if you just run the binary outside of docker, you might want to pin the listening address. 

The default behavior has not changed.