### PR TITLE
Added ability to skip containers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - @gbolo added ability to control the TLS client trust store
 - @gbolo added option to harden the TLS client
 - @chopmann added option to bind the http server to an address
-- @ibrokethecloud added ability to add custom key:value pairs as EXCLUDE_LABELS.
+- @ibrokethecloud added ability to add custom key:value pairs as EXCLUDE_LABEL.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - @gbolo added ability to control the TLS client trust store
 - @gbolo added option to harden the TLS client
 - @chopmann added option to bind the http server to an address
+- @ibrokethecloud added ability to add custom key:value pairs as EXCLUDE_LABELS.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ If you use multiline logging with raw, it's recommended to json encode the Data 
 * `BACKLOG` - suppress container tail backlog
 * `TAIL` - specify the number of lines in the log tail to capture when logspout starts (default `all`)
 * `DEBUG` - emit debug logs
-* `EXCLUDE_LABEL` - exclude logs with a given label
+* `EXCLUDE_LABEL` - exclude logs with a given label. The variable can be of the form `label_name` or `label_name:label_value`. If no explicit key:value pair is specified then the default label matching will be of the form `label_name = true`.
 * `INACTIVITY_TIMEOUT` - detect hang in Docker API (default 0)
 * `HTTP_BIND_ADDRESS` - configure which interface address to listen on (default 0.0.0.0)
 * `PORT` or `HTTP_PORT` - configure which port to listen on (default 80)

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ If you use multiline logging with raw, it's recommended to json encode the Data 
 * `BACKLOG` - suppress container tail backlog
 * `TAIL` - specify the number of lines in the log tail to capture when logspout starts (default `all`)
 * `DEBUG` - emit debug logs
-* `EXCLUDE_LABEL` - exclude logs with a given label. The variable can be of the form `label_name` or `label_name:label_value`. If no explicit key:value pair is specified then the default label matching will be of the form `label_name = true`.
+* `EXCLUDE_LABEL` - exclude containers with a given label. The label can have a value of true or a custom value matched with : after the label name like label_name:label_value.
 * `INACTIVITY_TIMEOUT` - detect hang in Docker API (default 0)
 * `HTTP_BIND_ADDRESS` - configure which interface address to listen on (default 0.0.0.0)
 * `PORT` or `HTTP_PORT` - configure which port to listen on (default 80)

--- a/router/pump.go
+++ b/router/pump.go
@@ -95,6 +95,7 @@ func ignoreContainer(container *docker.Container) bool {
 	excludeLabelArr := strings.Split(excludeLabel, ":")
 	if len(excludeLabelArr) == 2 {
 		excludeValue = excludeLabelArr[1]
+		excludeLabel = excludeLabelArr[0]
 	}
 
 	if value, ok := container.Config.Labels[excludeLabel]; ok {

--- a/router/pump.go
+++ b/router/pump.go
@@ -106,7 +106,10 @@ func ignoreContainer(container *docker.Container) bool {
 	}
 
 	if value, ok := container.Config.Labels[excludeLabel]; ok {
-		// Change check to match values from the default of true //
+		// If label is of the form kube-app:* then ignore all
+		// containers with label kube-app irrespective of their value.
+		// Else for a normal label definition make sure key:values on
+		// container match
 		return len(excludeLabel) > 0 && strings.ToLower(value) == strings.ToLower(excludeValue)
 
 	}
@@ -166,6 +169,7 @@ func (p *LogsPump) rename(event *docker.APIEvents) {
 
 // Run executes the pump
 func (p *LogsPump) Run() error {
+	debug("Making sure using my custom adapter")
 	inactivityTimeout := getInactivityTimeoutFromEnv()
 	debug("pump.Run(): using inactivity timeout: ", inactivityTimeout)
 

--- a/router/pump.go
+++ b/router/pump.go
@@ -89,27 +89,21 @@ func ignoreContainer(container *docker.Container) bool {
 
 	// Extra logic to allow excludeLabel to handle custom key pair values //
 
-	excludeString := getopt("EXCLUDE_LABEL", "")
-
-	excludeStringArr := strings.Split(excludeString, ":")
-	var excludeLabel, excludeValue string
-
-	if len(excludeStringArr) == 1 {
-		excludeLabel = excludeStringArr[0]
-		excludeValue = "true"
-	} else if len(excludeStringArr) == 2 {
-		excludeLabel = excludeStringArr[0]
-		excludeValue = excludeStringArr[1]
-	} else {
-		// Label definition may be invalid //
-		return false
+	excludeLabel := getopt("EXCLUDE_LABEL", "")
+	excludeValue := "true"
+	// support EXCLUDE_LABEL having a custom label value
+	excludeLabelArr := strings.Split(excludeLabel, ":")
+	if len(excludeLabelArr) == 2 {
+		excludeValue = excludeLabelArr[1]
 	}
 
 	if value, ok := container.Config.Labels[excludeLabel]; ok {
-		// If label is of the form kube-app:* then ignore all
-		// containers with label kube-app irrespective of their value.
-		// Else for a normal label definition make sure key:values on
-		// container match
+		return len(excludeLabel) > 0 && strings.ToLower(value) == strings.ToLower(excludeValue)
+	}
+	return false
+
+	if value, ok := container.Config.Labels[excludeLabel]; ok {
+		// Change check to match values from the default of true //
 		return len(excludeLabel) > 0 && strings.ToLower(value) == strings.ToLower(excludeValue)
 
 	}

--- a/router/pump.go
+++ b/router/pump.go
@@ -87,8 +87,6 @@ func ignoreContainer(container *docker.Container) bool {
 		}
 	}
 
-	// Extra logic to allow excludeLabel to handle custom key pair values //
-
 	excludeLabel := getopt("EXCLUDE_LABEL", "")
 	excludeValue := "true"
 	// support EXCLUDE_LABEL having a custom label value
@@ -157,7 +155,6 @@ func (p *LogsPump) rename(event *docker.APIEvents) {
 
 // Run executes the pump
 func (p *LogsPump) Run() error {
-	debug("Making sure using my custom adapter")
 	inactivityTimeout := getInactivityTimeoutFromEnv()
 	debug("pump.Run(): using inactivity timeout: ", inactivityTimeout)
 

--- a/router/pump.go
+++ b/router/pump.go
@@ -101,13 +101,6 @@ func ignoreContainer(container *docker.Container) bool {
 		return len(excludeLabel) > 0 && strings.ToLower(value) == strings.ToLower(excludeValue)
 	}
 	return false
-
-	if value, ok := container.Config.Labels[excludeLabel]; ok {
-		// Change check to match values from the default of true //
-		return len(excludeLabel) > 0 && strings.ToLower(value) == strings.ToLower(excludeValue)
-
-	}
-	return false
 }
 
 func ignoreContainerTTY(container *docker.Container) bool {

--- a/router/pump_test.go
+++ b/router/pump_test.go
@@ -74,6 +74,24 @@ func TestPumpIgnoreContainer(t *testing.T) {
 	}
 }
 
+func TestPumpIgnoreContainerCustomLabels(t *testing.T) {
+	os.Setenv("EXCLUDE_LABEL", "k8s-app:canal")
+	defer os.Unsetenv("EXCLUDE_LABEL")
+	containers := []struct {
+		in  *docker.Config
+		out bool
+	}{
+		{&docker.Config{Labels: map[string]string{"k8s-app": "canal"}}, true},
+		{&docker.Config{Labels: map[string]string{"app": "demo-app"}}, false},
+	}
+
+	for _, conf := range containers {
+		if actual := ignoreContainer(&docker.Container{Config: conf.in}); actual != conf.out {
+			t.Errorf("expected %v got %v", conf.out, actual)
+		}
+	}
+}
+
 func TestPumpIgnoreContainerAllowTTYDefault(t *testing.T) {
 	containers := []struct {
 		in  *docker.Config


### PR DESCRIPTION
Currently EXCLUDE_LABEL expects the containers to have labels of the form
`label_name:true` 

This works fine for certain scenarios but cant handle scenarios in kubernetes where we want to ignore kube-system containers.

The PR allows EXCLUDE_LABELS to be of the form `label_name` or `label_name:value`

This should keep it backward compatible while allowing us to use new label key value pairs to handle cases where we can ignore entire namespaces in k8s.