### PR TITLE
Add optional TCP framing to syslog adapter

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -28,11 +28,14 @@ var (
 	econnResetErrStr string
 )
 
+// TCPFraming represents the type of framing to use for syslog messages
 type TCPFraming string
 
 const (
-	TraditionalTCPFraming  TCPFraming = "traditional"   // LF framing
-	OctetCountedTCPFraming            = "octet-counted" // https://tools.ietf.org/html/rfc6587#section-3.4.1
+	// TraditionalTCPFraming is the traditional LF framing of syslog messages on the wire
+	TraditionalTCPFraming TCPFraming = "traditional"
+	// OctetCountedTCPFraming prepends the size of each message before the message. https://tools.ietf.org/html/rfc6587#section-3.4.1
+	OctetCountedTCPFraming = "octet-counted"
 )
 
 func init() {

--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -35,7 +35,7 @@ const (
 	// TraditionalTCPFraming is the traditional LF framing of syslog messages on the wire
 	TraditionalTCPFraming TCPFraming = "traditional"
 	// OctetCountedTCPFraming prepends the size of each message before the message. https://tools.ietf.org/html/rfc6587#section-3.4.1
-	OctetCountedTCPFraming = "octet-counted"
+	OctetCountedTCPFraming TCPFraming = "octet-counted"
 )
 
 func init() {


### PR DESCRIPTION
Add a new syslog configuration value: `SYSLOG_TCP_FRAMING` for optional framing of syslog messages over TCP. Adding octet framing as an alternative to traditional framing.

`SYSLOG_TCP_FRAMING=octet-counted` frames messages as described in [RFC6587 (Syslog over TCP) 3.4.1]( https://tools.ietf.org/html/rfc6587#section-3.4.1) and [RFC5424 (Syslog over TLS) 4.3](https://tools.ietf.org/html/rfc5425#section-4.3). This prefixes each message with the length of the message to allow consumers to easily determine where the message ends (rather than traditional LF framing). This also enables multiline Syslog messages without escaping.

I modeled the implementation after [Rsyslog's](https://www.rsyslog.com/doc/v8-stable/configuration/modules/omfwd.html#tcp-framing). I opted to add a general `SYSLOG_TCP_FRAMING` rather than something like `SYSLOG_OCTET_FRAMING` to allow this to be extended to additional framing strategies.

I followed the existing pattern of putting these configuration options as package level variables (`tcpFraming`) though my instinct was to attach it to the `syslog.Adapter` type.

This keeps the default as LF framing for backwards compatibility though octet-counted framing is preferred when it is known the downstream consumer can handle it to reduce ambiguity or malformed parsing arising from stray line feeds.

[1] https://tools.ietf.org/html/rfc6587#section-3.4.1
[2] https://tools.ietf.org/html/rfc5425#section-4.3