### PR TITLE
add a link to logspout-fluentd

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ The standard distribution of logspout comes with all modules defined in this rep
  * [logspout-logstash](https://github.com/looplab/logspout-logstash)
  * [logspout-redis-logstash](https://github.com/rtoma/logspout-redis-logstash)
  * [logspout-gelf](https://github.com/micahhausler/logspout-gelf) for Graylog
+ * [logspout-fluentd](https://github.com/dsouzajude/logspout-fluentd) for fluentd - instead of using fluentd log driver
+ 
 
 ### Loggly support
 

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ The standard distribution of logspout comes with all modules defined in this rep
  * [logspout-logstash](https://github.com/looplab/logspout-logstash)
  * [logspout-redis-logstash](https://github.com/rtoma/logspout-redis-logstash)
  * [logspout-gelf](https://github.com/micahhausler/logspout-gelf) for Graylog
- * [logspout-fluentd](https://github.com/dsouzajude/logspout-fluentd) for fluentd - instead of using fluentd log driver
+ * [logspout-fluentd](https://github.com/dsouzajude/logspout-fluentd) for fluentd or fluent-bit - instead of using fluentd log driver
  
 
 ### Loggly support


### PR DESCRIPTION
This is a new implementation of logspout-fluentd (2019) (https://github.com/dsouzajude/logspout-fluentd)
to combine logspout and fluentd in replacement of fluentd log driver

a detail post of how logspout-fluentd was designed : https://medium.com/magine-engineering/using-fluentd-log-driver-but-still-want-to-debug-your-container-logs-locally-try-logspout-c5b9f6ca9d07