### PR TITLE
adapters/syslog: enforce RFC size limits in message fields

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -92,10 +92,18 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 	var tmplStr string
 	switch format {
 	case "rfc5424":
-		tmplStr = fmt.Sprintf("<%s>1 %s %s %s %s - %s %s\n",
+		// notes from RFC:
+		// - there is no upper limit for the entire message and depends on the transport in use
+		// - the HOSTNAME field must not exceed 255 characters
+		// - the TAG field must not exceed 48 characters
+		// - the PROCID field must not exceed 128 characters
+		tmplStr = fmt.Sprintf("<%s>1 %s %.255s %.48s %.128s - %s %s\n",
 			priority, timestamp, hostname, tag, pid, structuredData, data)
 	case "rfc3164":
-		tmplStr = fmt.Sprintf("<%s>%s %s %s[%s]: %s\n",
+		// notes from RFC:
+		// - the entire message must be <= 1024 bytes
+		// - the TAG field must not exceed 32 characters
+		tmplStr = fmt.Sprintf("<%s>%s %s %.32s[%s]: %s\n",
 			priority, timestamp, hostname, tag, pid, data)
 	default:
 		return nil, errors.New("unsupported syslog format: " + format)


### PR DESCRIPTION
* for rfc5424 messages:
  - the HOSTNAME field must not exceed 255 characters
  - the TAG field must not exceed 48 characters
  - the PROCID field must not exceed 128 characters
* for rfc3164 messages:
  - the TAG field must not exceed 32 characters

*Note:* there are other more intricate size limits that are not easy to implement with the current approach of using Go templates. However the limits in this PR should account for the most problematic cases, i.e. container names too long to fit in the TAG field.

Ref: https://tools.ietf.org/html/rfc5424#section-6
Ref: https://tools.ietf.org/html/rfc3164#section-4

Fixes: #467