### PR TITLE
adapters/syslog: add ContainerNameSplitN utility message function

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -259,3 +259,8 @@ func (m *Message) Timestamp() string {
 func (m *Message) ContainerName() string {
 	return m.Message.Container.Name[1:]
 }
+
+// ContainerNameSplitN returns the message's container name sliced at most "n" times using "sep"
+func (m *Message) ContainerNameSplitN(sep string, n int) []string {
+	return strings.SplitN(m.ContainerName(), sep, n)
+}


### PR DESCRIPTION
* returns the message's container name sliced at most `n` times using `sep`
* useful for Docker Swarm environments where container names use established conventions

For example, to obtain only the service name of a replicated service from the traditional
`service_name.slot.id` convention:

    SYSLOG_TAG='{{index (.ContainerNameSplitN "." 2) 0}}'