### PR TITLE
Refactored syslog adapter to improve implementation

### DIFF
--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -156,7 +156,7 @@ func getRetryCount() uint {
 	return defaultRetryCount
 }
 
-func isTCPConnecion(conn net.Conn) bool {
+func isTCPConnection(conn net.Conn) bool {
 	switch conn.(type) {
 	case *net.TCPConn:
 		return true
@@ -189,7 +189,7 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 		return nil, err
 	}
 
-	connIsTCP := isTCPConnecion(conn)
+	connIsTCP := isTCPConnection(conn)
 	debug("setting connIsTCP to:", connIsTCP)
 
 	var tcpFraming TCPFraming

--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -167,11 +167,11 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 
 // Parses SYSLOG_FORMAT from the environment and sets format
 func setFormat() error {
-	switch s := cfg.GetEnvDefault("SYSLOG_FORMAT", "rfc5424"); s {
-	case "rfc5424":
+	switch s := cfg.GetEnvDefault("SYSLOG_FORMAT", string(Rfc5424Format)); s {
+	case string(Rfc5424Format):
 		format = Rfc5424Format
 		return nil
-	case "rfc3164":
+	case string(Rfc3164Format):
 		format = Rfc3164Format
 		return nil
 	default:
@@ -181,11 +181,11 @@ func setFormat() error {
 
 // Parses SYSLOG_TCP_FRAMING from the environment and sets tcpFraming
 func setTCPFraming() error {
-	switch s := cfg.GetEnvDefault("SYSLOG_TCP_FRAMING", "traditional"); s {
-	case "traditional":
+	switch s := cfg.GetEnvDefault("SYSLOG_TCP_FRAMING", string(TraditionalTCPFraming)); s {
+	case string(TraditionalTCPFraming):
 		tcpFraming = TraditionalTCPFraming
 		return nil
-	case "octet-counted":
+	case string(OctetCountedTCPFraming):
 		tcpFraming = OctetCountedTCPFraming
 		return nil
 	default:

--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -87,26 +87,31 @@ func getFieldTemplates(route *router.Route) (*FieldTemplates, error) {
 	if tmpl.priority, err = template.New("priority").Parse(s); err != nil {
 		return nil, err
 	}
+	debug("setting priority to:", s)
 
 	s = cfg.GetEnvDefault("SYSLOG_TIMESTAMP", "{{.Timestamp}}")
 	if tmpl.timestamp, err = template.New("timestamp").Parse(s); err != nil {
 		return nil, err
 	}
+	debug("setting timestamp to:", s)
 
 	s = getHostname()
 	if tmpl.hostname, err = template.New("hostname").Parse(s); err != nil {
 		return nil, err
 	}
+	debug("setting hostname to:", s)
 
 	s = cfg.GetEnvDefault("SYSLOG_TAG", "{{.ContainerName}}"+route.Options["append_tag"])
 	if tmpl.tag, err = template.New("tag").Parse(s); err != nil {
 		return nil, err
 	}
+	debug("setting tag to:", s)
 
 	s = cfg.GetEnvDefault("SYSLOG_PID", "{{.Container.State.Pid}}")
 	if tmpl.pid, err = template.New("pid").Parse(s); err != nil {
 		return nil, err
 	}
+	debug("setting pid to:", s)
 
 	s = cfg.GetEnvDefault("SYSLOG_STRUCTURED_DATA", "")
 	if route.Options["structured_data"] != "" {
@@ -120,11 +125,13 @@ func getFieldTemplates(route *router.Route) (*FieldTemplates, error) {
 	if tmpl.structuredData, err = template.New("structuredData").Parse(s); err != nil {
 		return nil, err
 	}
+	debug("setting structuredData to:", s)
 
 	s = cfg.GetEnvDefault("SYSLOG_DATA", "{{.Data}}")
 	if tmpl.data, err = template.New("data").Parse(s); err != nil {
 		return nil, err
 	}
+	debug("setting data to:", s)
 
 	return &tmpl, nil
 }
@@ -144,6 +151,7 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 	if err = setFormat(); err != nil {
 		return nil, err
 	}
+	debug("setting format to:", format)
 
 	var tmpl *FieldTemplates
 	if tmpl, err = getFieldTemplates(route); err != nil {
@@ -154,6 +162,7 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 		if err = setTCPFraming(); err != nil {
 			return nil, err
 		}
+		debug("setting tcpFraming to:", tcpFraming)
 	}
 
 	return &Adapter{

--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -31,6 +31,8 @@ const (
 	// OctetCountedTCPFraming prepends the size of each message before the message. https://tools.ietf.org/html/rfc6587#section-3.4.1
 	OctetCountedTCPFraming TCPFraming = "octet-counted"
 
+	defaultFormat     = Rfc5424Format
+	defaultTCPFraming = TraditionalTCPFraming
 	defaultRetryCount = 10
 )
 
@@ -56,13 +58,13 @@ func debug(v ...interface{}) {
 }
 
 func getFormat() (Format, error) {
-	switch s := cfg.GetEnvDefault("SYSLOG_FORMAT", string(Rfc5424Format)); s {
+	switch s := cfg.GetEnvDefault("SYSLOG_FORMAT", string(defaultFormat)); s {
 	case string(Rfc5424Format):
 		return Rfc5424Format, nil
 	case string(Rfc3164Format):
 		return Rfc3164Format, nil
 	default:
-		return Rfc5424Format, fmt.Errorf("unknown SYSLOG_FORMAT value: %s", s)
+		return defaultFormat, fmt.Errorf("unknown SYSLOG_FORMAT value: %s", s)
 	}
 }
 
@@ -135,13 +137,13 @@ func getFieldTemplates(route *router.Route) (*FieldTemplates, error) {
 }
 
 func getTCPFraming() (TCPFraming, error) {
-	switch s := cfg.GetEnvDefault("SYSLOG_TCP_FRAMING", string(TraditionalTCPFraming)); s {
+	switch s := cfg.GetEnvDefault("SYSLOG_TCP_FRAMING", string(defaultTCPFraming)); s {
 	case string(TraditionalTCPFraming):
 		return TraditionalTCPFraming, nil
 	case string(OctetCountedTCPFraming):
 		return OctetCountedTCPFraming, nil
 	default:
-		return TraditionalTCPFraming, fmt.Errorf("unknown SYSLOG_TCP_FRAMING value: %s", s)
+		return defaultTCPFraming, fmt.Errorf("unknown SYSLOG_TCP_FRAMING value: %s", s)
 	}
 }
 

--- a/adapters/syslog/syslog.go
+++ b/adapters/syslog/syslog.go
@@ -215,7 +215,7 @@ func NewSyslogAdapter(route *router.Route) (router.LogAdapter, error) {
 	}, nil
 }
 
-// Field templates for rendering Syslog messages
+// FieldTemplates for rendering Syslog messages
 type FieldTemplates struct {
 	priority       *template.Template
 	timestamp      *template.Template

--- a/adapters/syslog/syslog_test.go
+++ b/adapters/syslog/syslog_test.go
@@ -91,15 +91,16 @@ func TestSyslogOctetFraming(t *testing.T) {
 }
 
 func TestSyslogRetryCount(t *testing.T) {
+	const defaultRetryCount = uint(10)
 	newRetryCount := uint(20)
 	os.Setenv("RETRY_COUNT", strconv.Itoa(int(newRetryCount)))
-	setRetryCount()
+	retryCount, _ := getRetryCount()
 	if retryCount != newRetryCount {
 		t.Errorf("expected %v got %v", newRetryCount, retryCount)
 	}
 
 	os.Unsetenv("RETRY_COUNT")
-	setRetryCount()
+	retryCount, _ = getRetryCount()
 	if retryCount != defaultRetryCount {
 		t.Errorf("expected %v got %v", defaultRetryCount, retryCount)
 	}
@@ -219,7 +220,7 @@ func sendLogstream(stream chan *router.Message, messages chan string, adapter ro
 			},
 		}
 		stream <- msg.Message
-		b, _ := msg.Render(adapter.(*Adapter).tmpl)
+		b, _ := msg.Render(adapter.(*Adapter).format, adapter.(*Adapter).tmpl)
 		messages <- string(b)
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/adapters/syslog/syslog_test.go
+++ b/adapters/syslog/syslog_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"text/template"
 	"time"
 
 	_ "github.com/gliderlabs/logspout/transports/tcp"
@@ -135,7 +134,7 @@ func TestSyslogReconnectOnClose(t *testing.T) {
 				<-messages
 				msgnum++
 			}
-			check(t, adapter.(*Adapter).tmpl, <-messages, msg)
+			check(t, <-messages, msg)
 			msgnum++
 		case <-timeout:
 			adapter.(*Adapter).conn.Close()
@@ -226,7 +225,7 @@ func sendLogstream(stream chan *router.Message, messages chan string, adapter ro
 	}
 }
 
-func check(t *testing.T, tmpl *template.Template, in string, out string) {
+func check(t *testing.T, in string, out string) {
 	if in != out {
 		t.Errorf("expected: %s\ngot: %s\n", in, out)
 	}

--- a/adapters/syslog/syslog_test.go
+++ b/adapters/syslog/syslog_test.go
@@ -90,6 +90,64 @@ func TestSyslogOctetFraming(t *testing.T) {
 	}
 }
 
+func TestSysLogFormat(t *testing.T) {
+	defer os.Unsetenv("SYSLOG_FORMAT")
+
+	newFormat := Rfc3164Format
+	os.Setenv("SYSLOG_FORMAT", string(newFormat))
+	format, err := getFormat()
+	if err != nil {
+		t.Fatal("unexpected error: ", err)
+	}
+	if format != newFormat {
+		t.Errorf("expected %v got %v", newFormat, format)
+	}
+
+	os.Unsetenv("SYSLOG_FORMAT")
+	format, err = getFormat()
+	if err != nil {
+		t.Fatal("unexpected error: ", err)
+	}
+	if format != defaultFormat {
+		t.Errorf("expected %v got %v", defaultFormat, format)
+	}
+
+	os.Setenv("SYSLOG_FORMAT", "invalid-option")
+	_, err = getFormat()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestSysLogTCPFraming(t *testing.T) {
+	defer os.Unsetenv("SYSLOG_TCP_FRAMING")
+
+	newTCPFraming := OctetCountedTCPFraming
+	os.Setenv("SYSLOG_TCP_FRAMING", string(newTCPFraming))
+	tcpFraming, err := getTCPFraming()
+	if err != nil {
+		t.Fatal("unexpected error: ", err)
+	}
+	if tcpFraming != newTCPFraming {
+		t.Errorf("expected %v got %v", newTCPFraming, tcpFraming)
+	}
+
+	os.Unsetenv("SYSLOG_TCP_FRAMING")
+	tcpFraming, err = getTCPFraming()
+	if err != nil {
+		t.Fatal("unexpected error: ", err)
+	}
+	if tcpFraming != defaultTCPFraming {
+		t.Errorf("expected %v got %v", defaultTCPFraming, tcpFraming)
+	}
+
+	os.Setenv("SYSLOG_TCP_FRAMING", "invalid-option")
+	_, err = getTCPFraming()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
 func TestSyslogRetryCount(t *testing.T) {
 	newRetryCount := uint(20)
 	os.Setenv("RETRY_COUNT", strconv.Itoa(int(newRetryCount)))

--- a/adapters/syslog/syslog_test.go
+++ b/adapters/syslog/syslog_test.go
@@ -35,7 +35,7 @@ var (
 			Hostname: "8dfafdbc3a40",
 		},
 	}
-	hostHostnameFilename = "/etc/host_hostname"
+	hostHostnameFilename = "/tmp/host_hostname"
 	hostnameContent      = "hostname"
 	badHostnameContent   = "hostname\r\n"
 )
@@ -91,16 +91,15 @@ func TestSyslogOctetFraming(t *testing.T) {
 }
 
 func TestSyslogRetryCount(t *testing.T) {
-	const defaultRetryCount = uint(10)
 	newRetryCount := uint(20)
 	os.Setenv("RETRY_COUNT", strconv.Itoa(int(newRetryCount)))
-	retryCount, _ := getRetryCount()
+	retryCount := getRetryCount()
 	if retryCount != newRetryCount {
 		t.Errorf("expected %v got %v", newRetryCount, retryCount)
 	}
 
 	os.Unsetenv("RETRY_COUNT")
-	retryCount, _ = getRetryCount()
+	retryCount = getRetryCount()
 	if retryCount != defaultRetryCount {
 		t.Errorf("expected %v got %v", defaultRetryCount, retryCount)
 	}


### PR DESCRIPTION
* add constants, variable and setter function for syslog format
* separate RFC-based template into fields-based templates
  * perform message assembly and RFC size truncation of fields during message rendering
  * fixes reported premature RFC size truncation of fields
* simplify tcpFraming logic
  * replace `isTCPConnecion()` with a boolean in `Adapter` to indicate a UDP transport
* cleaner handling of connection reset by peer errors
  * use `errors.Is()` (from Go 1.13) instead of string-based comparison
* use constants string values when parsing
  * ensure string literals are only used once when defining their constants
* add debugging information for all variables
* move adapter-related variables into the `Adapter` struct
  * variables: `retryCount`, `format` and `tcpFraming`
  * transform setter functions to getters

Example console output with debugging enabled:

```
2020/05/06 19:17:57 setting allowTTY to: false
2020/05/06 19:17:57 # logspout v3.2.10 by gliderlabs
2020/05/06 19:17:57 # adapters: udp multiline raw syslog tcp tls
2020/05/06 19:17:57 # options :
2020/05/06 19:17:57 debug:1
2020/05/06 19:17:57 persist:/mnt/routes
2020/05/06 19:17:57 setting format to: rfc5424
2020/05/06 19:17:57 setting priority to: {{.Priority}}
2020/05/06 19:17:57 setting timestamp to: {{.Timestamp}}
2020/05/06 19:17:57 setting hostname to: {{.Container.Config.Hostname}}
2020/05/06 19:17:57 setting tag to: {{ .ContainerName }}-{{ .ContainerName }}-{{ .ContainerName }}-{{ .ContainerName }}-{{ .ContainerName }}
2020/05/06 19:17:57 setting pid to: {{.Container.State.Pid}}
2020/05/06 19:17:57 setting structuredData to: -
2020/05/06 19:17:57 setting data to: {{.Data}}
2020/05/06 19:17:57 setting tcpFraming to: traditional
2020/05/06 19:17:57 setting retryCount to: 10
2020/05/06 19:17:57 # jobs    : routes http[logs,routes,health]:80 pump
2020/05/06 19:17:57 # routes  :
#   ADAPTER             ADDRESS         CONTAINERS      SOURCES OPTIONS
#   multiline+syslog+tcplocalhost:9999                          map[]
2020/05/06 19:17:57 pump.Run(): using inactivity timeout:  0s
2020/05/06 19:17:57 pump.pumpLogs(): 4ff79f994cfe ignored: environ ignore
```

Example traffic using TCP framing `octet-counted` and format RFC5424:

```
106 <14>1 2020-05-06T10:19:12Z 33de329808d9 vibrant_ride 109126 - - PING localhost (127.0.0.1): 56 data bytes
116 <14>1 2020-05-06T10:19:12Z 33de329808d9 vibrant_ride 109126 - - 64 bytes from 127.0.0.1: seq=0 ttl=64 time=0.092 ms
116 <14>1 2020-05-06T10:19:13Z 33de329808d9 vibrant_ride 109126 - - 64 bytes from 127.0.0.1: seq=1 ttl=64 time=0.096 ms
116 <14>1 2020-05-06T10:19:14Z 33de329808d9 vibrant_ride 109126 - - 64 bytes from 127.0.0.1: seq=2 ttl=64 time=0.097 ms
116 <14>1 2020-05-06T10:19:15Z 33de329808d9 vibrant_ride 109126 - - 64 bytes from 127.0.0.1: seq=3 ttl=64 time=0.116 ms
116 <14>1 2020-05-06T10:19:16Z 33de329808d9 vibrant_ride 109126 - - 64 bytes from 127.0.0.1: seq=4 ttl=64 time=0.097 ms
65 <14>1 2020-05-06T10:19:16Z 33de329808d9 vibrant_ride 109126 - -
98 <14>1 2020-05-06T10:19:16Z 33de329808d9 vibrant_ride 109126 - - --- localhost ping statistics ---
122 <14>1 2020-05-06T10:19:16Z 33de329808d9 vibrant_ride 109126 - - 5 packets transmitted, 5 packets received, 0% packet loss
110 <14>1 2020-05-06T10:19:16Z 33de329808d9 vibrant_ride 109126 - - round-trip min/avg/max = 0.092/0.099/0.116 ms
```

Example traffic using TCP framing `traditional` and format RFC5424:

```
<14>1 2020-05-06T10:20:11Z 6674a8df65e2 amazing_johnson 109438 - - PING localhost (127.0.0.1): 56 data bytes
<14>1 2020-05-06T10:20:11Z 6674a8df65e2 amazing_johnson 109438 - - 64 bytes from 127.0.0.1: seq=0 ttl=64 time=0.088 ms
<14>1 2020-05-06T10:20:12Z 6674a8df65e2 amazing_johnson 109438 - - 64 bytes from 127.0.0.1: seq=1 ttl=64 time=0.118 ms
<14>1 2020-05-06T10:20:13Z 6674a8df65e2 amazing_johnson 109438 - - 64 bytes from 127.0.0.1: seq=2 ttl=64 time=0.126 ms
<14>1 2020-05-06T10:20:14Z 6674a8df65e2 amazing_johnson 109438 - - 64 bytes from 127.0.0.1: seq=3 ttl=64 time=0.109 ms
<14>1 2020-05-06T10:20:15Z 6674a8df65e2 amazing_johnson 109438 - - 64 bytes from 127.0.0.1: seq=4 ttl=64 time=0.094 ms
<14>1 2020-05-06T10:20:15Z 6674a8df65e2 amazing_johnson 109438 - -
<14>1 2020-05-06T10:20:15Z 6674a8df65e2 amazing_johnson 109438 - - --- localhost ping statistics ---
<14>1 2020-05-06T10:20:15Z 6674a8df65e2 amazing_johnson 109438 - - 5 packets transmitted, 5 packets received, 0% packet loss
<14>1 2020-05-06T10:20:15Z 6674a8df65e2 amazing_johnson 109438 - - round-trip min/avg/max = 0.088/0.107/0.126 ms
```

Example traffic using a long `SYSLOG_TAG` template, TCP framing `octet-counted` and format RFC5424:

```
142 <14>1 2020-05-06T10:18:27Z c8f3df967674 cranky_rhodes-cranky_rhodes-cranky_rhodes-cranky 108648 - - PING localhost (127.0.0.1): 56 data bytes
152 <14>1 2020-05-06T10:18:27Z c8f3df967674 cranky_rhodes-cranky_rhodes-cranky_rhodes-cranky 108648 - - 64 bytes from 127.0.0.1: seq=0 ttl=64 time=0.089 ms
152 <14>1 2020-05-06T10:18:28Z c8f3df967674 cranky_rhodes-cranky_rhodes-cranky_rhodes-cranky 108648 - - 64 bytes from 127.0.0.1: seq=1 ttl=64 time=0.152 ms
152 <14>1 2020-05-06T10:18:29Z c8f3df967674 cranky_rhodes-cranky_rhodes-cranky_rhodes-cranky 108648 - - 64 bytes from 127.0.0.1: seq=2 ttl=64 time=0.126 ms
152 <14>1 2020-05-06T10:18:30Z c8f3df967674 cranky_rhodes-cranky_rhodes-cranky_rhodes-cranky 108648 - - 64 bytes from 127.0.0.1: seq=3 ttl=64 time=0.139 ms
152 <14>1 2020-05-06T10:18:31Z c8f3df967674 cranky_rhodes-cranky_rhodes-cranky_rhodes-cranky 108648 - - 64 bytes from 127.0.0.1: seq=4 ttl=64 time=0.091 ms
101 <14>1 2020-05-06T10:18:31Z c8f3df967674 cranky_rhodes-cranky_rhodes-cranky_rhodes-cranky 108648 - -
134 <14>1 2020-05-06T10:18:31Z c8f3df967674 cranky_rhodes-cranky_rhodes-cranky_rhodes-cranky 108648 - - --- localhost ping statistics ---
158 <14>1 2020-05-06T10:18:31Z c8f3df967674 cranky_rhodes-cranky_rhodes-cranky_rhodes-cranky 108648 - - 5 packets transmitted, 5 packets received, 0% packet loss
146 <14>1 2020-05-06T10:18:31Z c8f3df967674 cranky_rhodes-cranky_rhodes-cranky_rhodes-cranky 108648 - - round-trip min/avg/max = 0.089/0.119/0.152 ms
```

Example traffic using TCP framing `traditional` and format RFC3164:

```
<14>2020-05-06T10:21:30Z d5bfdf2f27fa nostalgic_panini[109999]: PING localhost (127.0.0.1): 56 data bytes
<14>2020-05-06T10:21:30Z d5bfdf2f27fa nostalgic_panini[109999]: 64 bytes from 127.0.0.1: seq=0 ttl=64 time=0.114 ms
<14>2020-05-06T10:21:31Z d5bfdf2f27fa nostalgic_panini[109999]: 64 bytes from 127.0.0.1: seq=1 ttl=64 time=0.117 ms
<14>2020-05-06T10:21:32Z d5bfdf2f27fa nostalgic_panini[109999]: 64 bytes from 127.0.0.1: seq=2 ttl=64 time=0.108 ms
<14>2020-05-06T10:21:33Z d5bfdf2f27fa nostalgic_panini[109999]: 64 bytes from 127.0.0.1: seq=3 ttl=64 time=0.122 ms
<14>2020-05-06T10:21:34Z d5bfdf2f27fa nostalgic_panini[109999]: 64 bytes from 127.0.0.1: seq=4 ttl=64 time=0.138 ms
<14>2020-05-06T10:21:34Z d5bfdf2f27fa nostalgic_panini[109999]:
<14>2020-05-06T10:21:34Z d5bfdf2f27fa nostalgic_panini[109999]: --- localhost ping statistics ---
<14>2020-05-06T10:21:34Z d5bfdf2f27fa nostalgic_panini[109999]: 5 packets transmitted, 5 packets received, 0% packet loss
<14>2020-05-06T10:21:34Z d5bfdf2f27fa nostalgic_panini[109999]: round-trip min/avg/max = 0.108/0.119/0.138 ms
```

Example traffic using a long `SYSLOG_TAG` template, TCP framing `octet-counted` and format RFC3164:

```
122 <14>2020-05-06T10:22:33Z 1d956f1b1923 elated_vaughan-elated_vaughan-el[110375]: PING localhost (127.0.0.1): 56 data bytes
132 <14>2020-05-06T10:22:33Z 1d956f1b1923 elated_vaughan-elated_vaughan-el[110375]: 64 bytes from 127.0.0.1: seq=0 ttl=64 time=0.144 ms
132 <14>2020-05-06T10:22:34Z 1d956f1b1923 elated_vaughan-elated_vaughan-el[110375]: 64 bytes from 127.0.0.1: seq=1 ttl=64 time=0.111 ms
132 <14>2020-05-06T10:22:35Z 1d956f1b1923 elated_vaughan-elated_vaughan-el[110375]: 64 bytes from 127.0.0.1: seq=2 ttl=64 time=0.104 ms
132 <14>2020-05-06T10:22:36Z 1d956f1b1923 elated_vaughan-elated_vaughan-el[110375]: 64 bytes from 127.0.0.1: seq=3 ttl=64 time=0.133 ms
132 <14>2020-05-06T10:22:37Z 1d956f1b1923 elated_vaughan-elated_vaughan-el[110375]: 64 bytes from 127.0.0.1: seq=4 ttl=64 time=0.097 ms
81 <14>2020-05-06T10:22:37Z 1d956f1b1923 elated_vaughan-elated_vaughan-el[110375]:
114 <14>2020-05-06T10:22:37Z 1d956f1b1923 elated_vaughan-elated_vaughan-el[110375]: --- localhost ping statistics ---
138 <14>2020-05-06T10:22:37Z 1d956f1b1923 elated_vaughan-elated_vaughan-el[110375]: 5 packets transmitted, 5 packets received, 0% packet loss
126 <14>2020-05-06T10:22:37Z 1d956f1b1923 elated_vaughan-elated_vaughan-el[110375]: round-trip min/avg/max = 0.097/0.117/0.144 ms
```

In the above examples, the long (>> 48 chars) `SYSLOG_TAG` used to demonstrate the fix is:

    SYSLOG_TAG='{{.ContainerName}}-{{.ContainerName}}-{{.ContainerName}}-{{.ContainerName}}-{{.ContainerName}}'

**Note:** This is my first serious take at GoLang so any feedback is very welcome. I tried to follow the same coding standards used elsewhere in Logspout and added a bit of optimisation/cleansing from myself based on GoLang practices I researched around the web.

Fixes #474