### PR TITLE
use // + space for all human readable comments

### DIFF
--- a/router/routes.go
+++ b/router/routes.go
@@ -140,7 +140,7 @@ func (rm *RouteManager) Add(route *Route) error {
 	}
 	route.closer = make(chan struct{})
 	route.adapter = adapter
-	//Stop any existing route with this ID:
+	// Stop any existing route with this ID:
 	if rm.routes[route.ID] != nil {
 		rm.routes[route.ID].closer <- struct{}{}
 	}

--- a/router/routes_test.go
+++ b/router/routes_test.go
@@ -32,10 +32,10 @@ func TestRouterGetAll(t *testing.T) {
 func TestRouterNoDuplicateIds(t *testing.T) {
 	AdapterFactories.Register(newDummyAdapter, "syslog")
 
-	//Mock "running" so routes actually start running when added.
+	// Mock "running" so routes actually start running when added.
 	Routes.routing = true
 
-	//Start the first route.
+	// Start the first route.
 	route1 := &Route{
 		ID:      "abc",
 		Address: "someUrl",
@@ -45,7 +45,7 @@ func TestRouterNoDuplicateIds(t *testing.T) {
 		t.Error("Error adding route:", err)
 	}
 
-	//Start a second route with the same ID.
+	// Start a second route with the same ID.
 	var route2 = &Route{
 		ID:      "abc",
 		Address: "someUrl2",


### PR DESCRIPTION
human readable comments should be in the form of `// text` whereas compiler (or other non-human) comments should be in the form of `//text`