### PR TITLE
Allow non-browser websocket clients to access the /logs endpoint

### DIFF
--- a/httpstream/httpstream.go
+++ b/httpstream/httpstream.go
@@ -104,7 +104,7 @@ func normalName(name string) string {
 }
 
 func websocketStreamer(w http.ResponseWriter, req *http.Request, logstream chan *router.Message, closer chan struct{}) {
-	websocket.Handler(func(conn *websocket.Conn) {
+	websocket.Server{Handler: websocket.Handler(func(conn *websocket.Conn) {
 		for logline := range logstream {
 			if req.URL.Query().Get("source") != "" && logline.Source != req.URL.Query().Get("source") {
 				continue
@@ -115,7 +115,7 @@ func websocketStreamer(w http.ResponseWriter, req *http.Request, logstream chan 
 				return
 			}
 		}
-	}).ServeHTTP(w, req)
+	})}.ServeHTTP(w, req)
 }
 
 func httpStreamer(w http.ResponseWriter, req *http.Request, logstream chan *router.Message, multi bool) {


### PR DESCRIPTION
 ` websocket.Handler.ServeHTTP` serves to browser requests and was also causing logspout to crash when accessed by a client like `wscat` as they don't typically set the origin header (See https://github.com/gliderlabs/logspout/issues/412). This change bypasses the validation for origin header.