### PR TITLE
Release docker image for arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,5 +127,18 @@ clean:
 	docker rm $(shell docker ps -aq) || true
 	docker rmi $(NAME):dev $(NAME):$(VERSION) || true
 	docker rmi $(shell docker images -f 'dangling=true' -q) || true
+publish:
+	mkdir -vp ~/.docker/cli-plugins/
+	curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
+	chmod a+x ~/.docker/cli-plugins/docker-buildx
+	docker run -it --rm --privileged tonistiigi/binfmt --install all
+	docker buildx create --use --name mybuilder
+ifeq ($(CIRCLE_BRANCH), master)
+	docker buildx build --platform linux/arm64,linux/amd64 -t ${DOCKER_USERNAME}/logspout:${CIRCLE_BRANCH} -t ${DOCKER_USERNAME}/logspout:latest --push .
+endif
+
+ifeq ($(CIRCLE_BRANCH), release)
+	docker buildx build --push --platform linux/arm64,linux/amd64 -t ${DOCKER_USERNAME}/logspout:${VERSION} .
+endif
 
 .PHONY: release clean

--- a/circle.yml
+++ b/circle.yml
@@ -36,3 +36,19 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "release" ]; then
               make release
             fi
+  publish:
+    machine:
+      image: ubuntu-1604:202007-01
+    working_directory: /home/circleci/logspout
+    environment:
+      DEBUG: true
+    steps:
+      - checkout
+      - run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+      - run: make publish
+
+  version: 2
+  build_and_publish:
+    jobs:
+      - build
+      - publish


### PR DESCRIPTION
The following files have been modified:

- In circle.yml file added a new job **publish** in order to use buildx to build and push the image for both the platforms to dockerhub.
