### PR TITLE
retrieve logs from already started containers

### DIFF
--- a/router/pump.go
+++ b/router/pump.go
@@ -180,7 +180,7 @@ func (p *LogsPump) Run() error {
 		p.pumpLogs(&docker.APIEvents{
 			ID:     normalID(containers[idx].ID),
 			Status: pumpEventStatusStartName,
-		}, false, inactivityTimeout)
+		}, backlog(), inactivityTimeout)
 	}
 	events := make(chan *docker.APIEvents)
 	err = p.client.AddEventListener(events)


### PR DESCRIPTION
Only one modification to have backlogs from already started containers. 